### PR TITLE
Formatting & Micro-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Star Calling Assist
+
 This plugin allows for crashed stars found around the game to be posted to a remote endpont.
 
-Posts can either be triggered manually by clicking the call-star button by the minimap when a star is found or automatically when a star is found by the player. This is configured in the plugin settings.
+Posts can either be triggered manually by clicking the call-star button by the minimap when a star is found or
+automatically when a star is found by the player. This is configured in the plugin settings.
 
 Posts are made in the following format to the endpoint specified in the plugin settings:
+
 ```json
 {
   "world": "world the star is in",
@@ -13,4 +16,5 @@ Posts are made in the following format to the endpoint specified in the plugin s
   "miners": "Players around the star. -1 if too far away to render players"
 }
 ```
+
 Authorization header is set to what is specified in the plugin settings.

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,26 @@
 plugins {
-	id 'java'
+    id 'java'
 }
 
 repositories {
-	mavenLocal()
-	maven {
-		url = 'https://repo.runelite.net'
-	}
-	mavenCentral()
+    mavenLocal()
+    maven {
+        url = 'https://repo.runelite.net'
+    }
+    mavenCentral()
 }
 
 def runeLiteVersion = 'latest.release'
 
 dependencies {
-	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
+    compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.20'
-	annotationProcessor 'org.projectlombok:lombok:1.18.20'
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-	testImplementation 'junit:junit:4.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
-	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+    testImplementation 'junit:junit:4.12'
+    testImplementation group: 'net.runelite', name: 'client', version: runeLiteVersion
+    testImplementation group: 'net.runelite', name: 'jshell', version: runeLiteVersion
 }
 
 group = 'com.starcallingassist'
@@ -28,5 +28,5 @@ version = '1.0-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
+    options.encoding = 'UTF-8'
 }

--- a/src/main/java/com/starcallingassist/CallSender.java
+++ b/src/main/java/com/starcallingassist/CallSender.java
@@ -1,51 +1,49 @@
 package com.starcallingassist;
 
+import javax.inject.Inject;
+import static net.runelite.http.api.RuneLiteAPI.GSON;
 import okhttp3.Callback;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 
-import javax.inject.Inject;
-
-import static net.runelite.http.api.RuneLiteAPI.GSON;
-
 public class CallSender
 {
-    private class CallData
-    {
-        private final int world;
-        private final int tier;
-        private final int miners;
-        private final String location;
-        private final String sender;
+	private class CallData
+	{
+		private final int world;
+		private final int tier;
+		private final int miners;
+		private final String location;
+		private final String sender;
 
-        public CallData(String sender, int world, int tier, String location, int miners)
-        {
-            this.sender = sender;
-            this.world = world;
-            this.tier = tier;
-            this.location = location;
-            this.miners = miners;
-        }
-    }
+		public CallData(String sender, int world, int tier, String location, int miners)
+		{
+			this.sender = sender;
+			this.world = world;
+			this.tier = tier;
+			this.location = location;
+			this.miners = miners;
+		}
+	}
 
-    @Inject
-    private StarCallingAssistConfig starConfig;
-    @Inject
-    private OkHttpClient okHttpClient;
+	@Inject
+	private StarCallingAssistConfig starConfig;
+	@Inject
+	private OkHttpClient okHttpClient;
 
-    public void sendCall(String username, int world, int tier, String location, int miners, Callback callback) throws IllegalArgumentException
-    {
-        Request request = new Request.Builder()
-            .url(starConfig.getEndpoint())
-            .addHeader("authorization", starConfig.getAuthorization())
-            .post(RequestBody.create(
-                MediaType.parse("application/json"),
-                // Doesn't include in-game name unless toggled on (default value is off)
-                GSON.toJson(new CallData(starConfig.includeIgn() ? username : "", world, tier, location, miners))))
-            .build();
+	public void sendCall(String username, int world, int tier, String location, int miners, Callback callback) throws IllegalArgumentException
+	{
+		Request request = new Request.Builder()
+			.url(starConfig.getEndpoint())
+			.addHeader("authorization", starConfig.getAuthorization())
+			.post(RequestBody.create(
+				MediaType.parse("application/json"),
+				// Doesn't include in-game name unless toggled on (default value is off)
+				GSON.toJson(new CallData(starConfig.includeIgn() ? username : "", world, tier, location, miners))))
+			.build();
 
-        okHttpClient.newCall(request).enqueue(callback);
-    }
+		okHttpClient.newCall(request).enqueue(callback);
+	}
 }

--- a/src/main/java/com/starcallingassist/CallSender.java
+++ b/src/main/java/com/starcallingassist/CallSender.java
@@ -1,10 +1,6 @@
 package com.starcallingassist;
 
-import okhttp3.Callback;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
+import okhttp3.*;
 
 import javax.inject.Inject;
 
@@ -14,20 +10,20 @@ public class CallSender
 {
     private class CallData
     {
-	private final int world;
-	private final int tier;
-	private final int miners;
-	private final String location;
-	private final String sender;
+        private final int world;
+        private final int tier;
+        private final int miners;
+        private final String location;
+        private final String sender;
 
-	public CallData(String sender, int world, int tier, String location, int miners)
-	{
-	    this.sender = sender;
-	    this.world = world;
-	    this.tier = tier;
-	    this.location = location;
-	    this.miners = miners;
-	}
+        public CallData(String sender, int world, int tier, String location, int miners)
+        {
+            this.sender = sender;
+            this.world = world;
+            this.tier = tier;
+            this.location = location;
+            this.miners = miners;
+        }
     }
 
     @Inject
@@ -37,15 +33,15 @@ public class CallSender
 
     public void sendCall(String username, int world, int tier, String location, int miners, Callback callback) throws IllegalArgumentException
     {
-	Request request = new Request.Builder()
-		.url(starConfig.getEndpoint())
-		.addHeader("authorization", starConfig.getAuthorization())
-		.post(RequestBody.create(
-			MediaType.parse("application/json"),
-			// Doesn't include in-game name unless toggled on (default value is off)
-			GSON.toJson(new CallData(starConfig.includeIgn() ? username : "", world, tier, location, miners))))
-		.build();
+        Request request = new Request.Builder()
+            .url(starConfig.getEndpoint())
+            .addHeader("authorization", starConfig.getAuthorization())
+            .post(RequestBody.create(
+                MediaType.parse("application/json"),
+                // Doesn't include in-game name unless toggled on (default value is off)
+                GSON.toJson(new CallData(starConfig.includeIgn() ? username : "", world, tier, location, miners))))
+            .build();
 
-	okHttpClient.newCall(request).enqueue(callback);
+        okHttpClient.newCall(request).enqueue(callback);
     }
 }

--- a/src/main/java/com/starcallingassist/CallSender.java
+++ b/src/main/java/com/starcallingassist/CallSender.java
@@ -1,6 +1,10 @@
 package com.starcallingassist;
 
-import okhttp3.*;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 
 import javax.inject.Inject;
 

--- a/src/main/java/com/starcallingassist/Star.java
+++ b/src/main/java/com/starcallingassist/Star.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public class Star
 {
     private static Star currentStar = null;
-    private static final int[] TIER_IDS = new int[]{41229,41228,41227,41226,41225,41224,41223,41021,41020};
+    private static final int[] TIER_IDS = new int[]{41229, 41228, 41227, 41226, 41225, 41224, 41223, 41021, 41020};
 
     public final GameObject starObject;
     public final int tier;
@@ -19,166 +19,179 @@ public class Star
 
     Star(GameObject starObject, int tier, WorldPoint location, int world)
     {
-	this.starObject = starObject;
-	this.tier = tier;
-	this.location = location;
-	this.world = world;
+        this.starObject = starObject;
+        this.tier = tier;
+        this.location = location;
+        this.world = world;
     }
 
-    public static Star getStar(){ return currentStar; }
+    public static Star getStar()
+    {
+        return currentStar;
+    }
 
-    public static void removeStar() {currentStar = null; }
+    public static void removeStar()
+    {
+        currentStar = null;
+    }
 
     public static void setStar(GameObject star, int tier, int world)
     {
-	currentStar = new Star(star, tier, star.getWorldLocation(), world);
+        currentStar = new Star(star, tier, star.getWorldLocation(), world);
     }
 
     public static int getTier(int id)
     {
-	for (int i = 0; i < TIER_IDS.length; i++)
-	    if(id == TIER_IDS[i])
-		return i + 1;
-	return -1;
+        for (int i = 0; i < TIER_IDS.length; i++) {
+            if (id == TIER_IDS[i]) {
+                return i + 1;
+            }
+        }
+
+        return -1;
     }
 
     public static String getLocationName(WorldPoint location)
     {
-	String locationName = LOCATION_NAMES.get(new Point(location.getX(), location.getY()));
-	if (locationName != null)
-	    return locationName;
-	return "unknown";
+        String locationName = LOCATION_NAMES.get(new Point(location.getX(), location.getY()));
+        if (locationName != null) {
+            return locationName;
+        }
+
+        return "unknown";
     }
 
     public static String getLocationName(int x, int y)
     {
-	String locationName = LOCATION_NAMES.get(new Point(x, y));
-	if (locationName != null)
-	    return locationName;
-	return "unknown";
+        String locationName = LOCATION_NAMES.get(new Point(x, y));
+        if (locationName != null) {
+            return locationName;
+        }
+
+        return "unknown";
     }
 
     private static final Map<Point, String> LOCATION_NAMES = new HashMap<Point, String>()
     {
-	{
+        {
 	    /*
 	    ASGARNIA
 	     */
-	    put(new Point(2974, 3241), "Rimmington mine");
-	    put(new Point(2940, 3280), "Crafting guild");
-	    put(new Point(2906, 3355), "West Falador mine");
-	    put(new Point(3030, 3348), "East Falador bank");
-	    put(new Point(3018, 3443), "North Dwarven Mine entrance");
-	    put(new Point(2882, 3474), "Taverley house portal");
+            put(new Point(2974, 3241), "Rimmington mine");
+            put(new Point(2940, 3280), "Crafting guild");
+            put(new Point(2906, 3355), "West Falador mine");
+            put(new Point(3030, 3348), "East Falador bank");
+            put(new Point(3018, 3443), "North Dwarven Mine entrance");
+            put(new Point(2882, 3474), "Taverley house portal");
 	    /*
 	    CRANDOR/KARAMJA
 	     */
-	    put(new Point(2736, 3221), "Brimhaven northwest gold mine");
-	    put(new Point(2742, 3143), "Southwest of Brimhaven Poh");
-	    put(new Point(2845, 3037), "Nature Altar mine north of Shilo");
-	    put(new Point(2827, 2999), "Shilo Village gem mine");
-	    put(new Point(2835, 3296), "North Crandor");
-	    put(new Point(2822, 3238), "South Crandor");
+            put(new Point(2736, 3221), "Brimhaven northwest gold mine");
+            put(new Point(2742, 3143), "Southwest of Brimhaven Poh");
+            put(new Point(2845, 3037), "Nature Altar mine north of Shilo");
+            put(new Point(2827, 2999), "Shilo Village gem mine");
+            put(new Point(2835, 3296), "North Crandor");
+            put(new Point(2822, 3238), "South Crandor");
 	    /*
 	    DESERT
 	     */
-	    put(new Point(3296, 3298), "Al Kharid mine");
-	    put(new Point(3276, 3164), "Al Kharid bank");
-	    put(new Point(3351, 3281), "North of Al Kharid PvP Arena");
-	    put(new Point(3424, 3160), "Nw of Uzer (Eagle's Eyrie)");
-	    put(new Point(3434, 2889), "Nardah bank");
-	    put(new Point(3316, 2867), "Agility Pyramid mine");
-	    put(new Point(3171, 2910), "Desert Quarry mine");
+            put(new Point(3296, 3298), "Al Kharid mine");
+            put(new Point(3276, 3164), "Al Kharid bank");
+            put(new Point(3351, 3281), "North of Al Kharid PvP Arena");
+            put(new Point(3424, 3160), "Nw of Uzer (Eagle's Eyrie)");
+            put(new Point(3434, 2889), "Nardah bank");
+            put(new Point(3316, 2867), "Agility Pyramid mine");
+            put(new Point(3171, 2910), "Desert Quarry mine");
 	    /*
 	    FELDIP HILLS/ISLE OF SOULS
 	     */
-	    put(new Point(2567, 2858), "Corsair Cove bank");
-	    put(new Point(2483, 2886), "Corsair Resource Area");
-	    put(new Point(2468, 2842), "Myths' Guild");
-	    put(new Point(2571, 2964), "Feldip Hills (aks fairy ring)");
-	    put(new Point(2630, 2993), "Rantz cave");
-	    put(new Point(2200, 2792), "Soul Wars south mine");
+            put(new Point(2567, 2858), "Corsair Cove bank");
+            put(new Point(2483, 2886), "Corsair Resource Area");
+            put(new Point(2468, 2842), "Myths' Guild");
+            put(new Point(2571, 2964), "Feldip Hills (aks fairy ring)");
+            put(new Point(2630, 2993), "Rantz cave");
+            put(new Point(2200, 2792), "Soul Wars south mine");
 	    /*
 	    FOSSIL ISLAND/MOS LE HARMLESS
 	     */
-	    put(new Point(3818, 3801), "Fossil Island Volcanic Mine entrance");
-	    put(new Point(3774, 3814), "Fossil Island rune rocks");
-	    put(new Point(3686, 2969), "Mos Le'Harmless west bank");
+            put(new Point(3818, 3801), "Fossil Island Volcanic Mine entrance");
+            put(new Point(3774, 3814), "Fossil Island rune rocks");
+            put(new Point(3686, 2969), "Mos Le'Harmless west bank");
 	    /*
 	    FREMENNIK/LUNAR ISLE
 	     */
-	    put(new Point(2727, 3683), "Keldagrim entrance mine");
-	    put(new Point(2683, 3699), "Rellekka mine");
-	    put(new Point(2393, 3814), "Jatizso mine entrance");
-	    put(new Point(2375, 3832), "Neitiznot south of rune rock");
-	    put(new Point(2528, 3887), "Miscellania mine (cip fairy ring)");
-	    put(new Point(2139, 3938), "Lunar Isle mine entrance");
+            put(new Point(2727, 3683), "Keldagrim entrance mine");
+            put(new Point(2683, 3699), "Rellekka mine");
+            put(new Point(2393, 3814), "Jatizso mine entrance");
+            put(new Point(2375, 3832), "Neitiznot south of rune rock");
+            put(new Point(2528, 3887), "Miscellania mine (cip fairy ring)");
+            put(new Point(2139, 3938), "Lunar Isle mine entrance");
 	    /*
 	    KANDARIN
 	     */
-	    put(new Point(2602, 3086), "Yanille bank");
-	    put(new Point(2624, 3141), "Port Khazard mine");
-	    put(new Point(2608, 3233), "Ardougne Monastery");
-	    put(new Point(2705, 3333), "South of Legends' Guild");
-	    put(new Point(2804, 3434), "Catherby bank");
-	    put(new Point(2589, 3478), "Coal Trucks west of Seers'");
+            put(new Point(2602, 3086), "Yanille bank");
+            put(new Point(2624, 3141), "Port Khazard mine");
+            put(new Point(2608, 3233), "Ardougne Monastery");
+            put(new Point(2705, 3333), "South of Legends' Guild");
+            put(new Point(2804, 3434), "Catherby bank");
+            put(new Point(2589, 3478), "Coal Trucks west of Seers'");
 	    /*
 	    KOUREND
 	     */
-	    put(new Point(1778, 3493), "Hosidius mine");
-	    put(new Point(1769, 3709), "Port Piscarilius mine in Kourend");
-	    put(new Point(1597, 3648), "Shayzien mine south of Kourend Castle");
-	    put(new Point(1534, 3747), "South Lovakengj bank");
-	    put(new Point(1437, 3840), "Lovakite mine");
-	    put(new Point(1760, 3853), "Arceuus dense essence mine");
+            put(new Point(1778, 3493), "Hosidius mine");
+            put(new Point(1769, 3709), "Port Piscarilius mine in Kourend");
+            put(new Point(1597, 3648), "Shayzien mine south of Kourend Castle");
+            put(new Point(1534, 3747), "South Lovakengj bank");
+            put(new Point(1437, 3840), "Lovakite mine");
+            put(new Point(1760, 3853), "Arceuus dense essence mine");
 	    /*
 	    KEBOS LOWLANDS
 	     */
-	    put(new Point(1322, 3816), "Mount Karuulm bank");
-	    put(new Point(1279, 3817), "Mount Karuulm mine");
-	    put(new Point(1210, 3651), "Kebos Swamp mine");
-	    put(new Point(1258, 3564), "Chambers of Xeric bank");
+            put(new Point(1322, 3816), "Mount Karuulm bank");
+            put(new Point(1279, 3817), "Mount Karuulm mine");
+            put(new Point(1210, 3651), "Kebos Swamp mine");
+            put(new Point(1258, 3564), "Chambers of Xeric bank");
 	    /*
 	    MISTHALIN
 	     */
-	    put(new Point(3258, 3408), "Varrock east bank");
-	    put(new Point(3290, 3353), "Southeast Varrock mine");
-	    put(new Point(3175, 3362), "Champions' Guild mine");
-	    put(new Point(3094, 3235), "Draynor Village");
-	    put(new Point(3153, 3150), "West Lumbridge Swamp mine");
-	    put(new Point(3230, 3155), "East Lumbridge Swamp mine");
+            put(new Point(3258, 3408), "Varrock east bank");
+            put(new Point(3290, 3353), "Southeast Varrock mine");
+            put(new Point(3175, 3362), "Champions' Guild mine");
+            put(new Point(3094, 3235), "Draynor Village");
+            put(new Point(3153, 3150), "West Lumbridge Swamp mine");
+            put(new Point(3230, 3155), "East Lumbridge Swamp mine");
 	    /*
 	    MORYTANIA
 	     */
-	    put(new Point(3635, 3340), "Darkmeyer ess. mine entrance");
-	    put(new Point(3650, 3214), "Theatre of Blood bank");
-	    put(new Point(3505, 3485), "Canifis bank");
-	    put(new Point(3500, 3219), "Burgh de Rott bank");
-	    put(new Point(3451, 3233), "Abandoned Mine west of Burgh");
+            put(new Point(3635, 3340), "Darkmeyer ess. mine entrance");
+            put(new Point(3650, 3214), "Theatre of Blood bank");
+            put(new Point(3505, 3485), "Canifis bank");
+            put(new Point(3500, 3219), "Burgh de Rott bank");
+            put(new Point(3451, 3233), "Abandoned Mine west of Burgh");
 	    /*
 	    PISCATORIS/GNOME STRONGHOLD
 	     */
-	    put(new Point(2444, 3490), "West of Grand Tree");
-	    put(new Point(2448, 3436), "Gnome Stronghold spirit tree");
-	    put(new Point(2341, 3635), "Piscatoris (akq fairy ring)");
+            put(new Point(2444, 3490), "West of Grand Tree");
+            put(new Point(2448, 3436), "Gnome Stronghold spirit tree");
+            put(new Point(2341, 3635), "Piscatoris (akq fairy ring)");
 	    /*
 	    TIRANNWN
 	     */
-	    put(new Point(2329, 3163), "Lletya");
-	    put(new Point(2269, 3158), "Isafdar runite rocks");
-	    put(new Point(3274, 6055), "Prifddinas Zalcano entrance");
-	    put(new Point(2318, 3269), "Arandar mine north of Lletya");
-	    put(new Point(2173, 3409), "Mynydd nw of Prifddinas");
+            put(new Point(2329, 3163), "Lletya");
+            put(new Point(2269, 3158), "Isafdar runite rocks");
+            put(new Point(3274, 6055), "Prifddinas Zalcano entrance");
+            put(new Point(2318, 3269), "Arandar mine north of Lletya");
+            put(new Point(2173, 3409), "Mynydd nw of Prifddinas");
 	    /*
 	    WILDERNESS
 	     */
-	    put(new Point(3108, 3569), "Mage of Zamorak mine (lvl 7 Wildy)");
-	    put(new Point(3018, 3593), "Skeleton mine (lvl 10 Wildy)");
-	    put(new Point(3093, 3756), "Hobgoblin mine (lvl 30 Wildy)");
-	    put(new Point(3057, 3887), "Lava maze runite mine (lvl 46 Wildy)");
-	    put(new Point(3049, 3940), "Pirates' Hideout (lvl 53 Wildy)");
-	    put(new Point(3091, 3962), "Mage Arena bank (lvl 56 Wildy)");
-	    put(new Point(3188, 3932), "Wilderness Resource Area");
-	}
+            put(new Point(3108, 3569), "Mage of Zamorak mine (lvl 7 Wildy)");
+            put(new Point(3018, 3593), "Skeleton mine (lvl 10 Wildy)");
+            put(new Point(3093, 3756), "Hobgoblin mine (lvl 30 Wildy)");
+            put(new Point(3057, 3887), "Lava maze runite mine (lvl 46 Wildy)");
+            put(new Point(3049, 3940), "Pirates' Hideout (lvl 53 Wildy)");
+            put(new Point(3091, 3962), "Mage Arena bank (lvl 56 Wildy)");
+            put(new Point(3188, 3932), "Wilderness Resource Area");
+        }
     };
 }

--- a/src/main/java/com/starcallingassist/Star.java
+++ b/src/main/java/com/starcallingassist/Star.java
@@ -1,197 +1,200 @@
 package com.starcallingassist;
 
+import java.awt.Point;
+import java.util.HashMap;
+import java.util.Map;
 import net.runelite.api.GameObject;
 import net.runelite.api.coords.WorldPoint;
 
-import java.awt.*;
-import java.util.HashMap;
-import java.util.Map;
-
 public class Star
 {
-    private static Star currentStar = null;
-    private static final int[] TIER_IDS = new int[]{41229, 41228, 41227, 41226, 41225, 41224, 41223, 41021, 41020};
+	private static Star currentStar = null;
+	private static final int[] TIER_IDS = new int[]{41229, 41228, 41227, 41226, 41225, 41224, 41223, 41021, 41020};
 
-    public final GameObject starObject;
-    public final int tier;
-    public final WorldPoint location;
-    public final int world;
+	public final GameObject starObject;
+	public final int tier;
+	public final WorldPoint location;
+	public final int world;
 
-    Star(GameObject starObject, int tier, WorldPoint location, int world)
-    {
-        this.starObject = starObject;
-        this.tier = tier;
-        this.location = location;
-        this.world = world;
-    }
+	Star(GameObject starObject, int tier, WorldPoint location, int world)
+	{
+		this.starObject = starObject;
+		this.tier = tier;
+		this.location = location;
+		this.world = world;
+	}
 
-    public static Star getStar()
-    {
-        return currentStar;
-    }
+	public static Star getStar()
+	{
+		return currentStar;
+	}
 
-    public static void removeStar()
-    {
-        currentStar = null;
-    }
+	public static void removeStar()
+	{
+		currentStar = null;
+	}
 
-    public static void setStar(GameObject star, int tier, int world)
-    {
-        currentStar = new Star(star, tier, star.getWorldLocation(), world);
-    }
+	public static void setStar(GameObject star, int tier, int world)
+	{
+		currentStar = new Star(star, tier, star.getWorldLocation(), world);
+	}
 
-    public static int getTier(int id)
-    {
-        for (int i = 0; i < TIER_IDS.length; i++) {
-            if (id == TIER_IDS[i]) {
-                return i + 1;
-            }
-        }
+	public static int getTier(int id)
+	{
+		for (int i = 0; i < TIER_IDS.length; i++)
+		{
+			if (id == TIER_IDS[i])
+			{
+				return i + 1;
+			}
+		}
 
-        return -1;
-    }
+		return -1;
+	}
 
-    public static String getLocationName(WorldPoint location)
-    {
-        String locationName = LOCATION_NAMES.get(new Point(location.getX(), location.getY()));
-        if (locationName != null) {
-            return locationName;
-        }
+	public static String getLocationName(WorldPoint location)
+	{
+		String locationName = LOCATION_NAMES.get(new Point(location.getX(), location.getY()));
+		if (locationName != null)
+		{
+			return locationName;
+		}
 
-        return "unknown";
-    }
+		return "unknown";
+	}
 
-    public static String getLocationName(int x, int y)
-    {
-        String locationName = LOCATION_NAMES.get(new Point(x, y));
-        if (locationName != null) {
-            return locationName;
-        }
+	public static String getLocationName(int x, int y)
+	{
+		String locationName = LOCATION_NAMES.get(new Point(x, y));
+		if (locationName != null)
+		{
+			return locationName;
+		}
 
-        return "unknown";
-    }
+		return "unknown";
+	}
 
-    private static final Map<Point, String> LOCATION_NAMES = new HashMap<Point, String>()
-    {
-        {
+	private static final Map<Point, String> LOCATION_NAMES = new HashMap<Point, String>()
+	{
+		{
 	    /*
 	    ASGARNIA
 	     */
-            put(new Point(2974, 3241), "Rimmington mine");
-            put(new Point(2940, 3280), "Crafting guild");
-            put(new Point(2906, 3355), "West Falador mine");
-            put(new Point(3030, 3348), "East Falador bank");
-            put(new Point(3018, 3443), "North Dwarven Mine entrance");
-            put(new Point(2882, 3474), "Taverley house portal");
+			put(new Point(2974, 3241), "Rimmington mine");
+			put(new Point(2940, 3280), "Crafting guild");
+			put(new Point(2906, 3355), "West Falador mine");
+			put(new Point(3030, 3348), "East Falador bank");
+			put(new Point(3018, 3443), "North Dwarven Mine entrance");
+			put(new Point(2882, 3474), "Taverley house portal");
 	    /*
 	    CRANDOR/KARAMJA
 	     */
-            put(new Point(2736, 3221), "Brimhaven northwest gold mine");
-            put(new Point(2742, 3143), "Southwest of Brimhaven Poh");
-            put(new Point(2845, 3037), "Nature Altar mine north of Shilo");
-            put(new Point(2827, 2999), "Shilo Village gem mine");
-            put(new Point(2835, 3296), "North Crandor");
-            put(new Point(2822, 3238), "South Crandor");
+			put(new Point(2736, 3221), "Brimhaven northwest gold mine");
+			put(new Point(2742, 3143), "Southwest of Brimhaven Poh");
+			put(new Point(2845, 3037), "Nature Altar mine north of Shilo");
+			put(new Point(2827, 2999), "Shilo Village gem mine");
+			put(new Point(2835, 3296), "North Crandor");
+			put(new Point(2822, 3238), "South Crandor");
 	    /*
 	    DESERT
 	     */
-            put(new Point(3296, 3298), "Al Kharid mine");
-            put(new Point(3276, 3164), "Al Kharid bank");
-            put(new Point(3351, 3281), "North of Al Kharid PvP Arena");
-            put(new Point(3424, 3160), "Nw of Uzer (Eagle's Eyrie)");
-            put(new Point(3434, 2889), "Nardah bank");
-            put(new Point(3316, 2867), "Agility Pyramid mine");
-            put(new Point(3171, 2910), "Desert Quarry mine");
+			put(new Point(3296, 3298), "Al Kharid mine");
+			put(new Point(3276, 3164), "Al Kharid bank");
+			put(new Point(3351, 3281), "North of Al Kharid PvP Arena");
+			put(new Point(3424, 3160), "Nw of Uzer (Eagle's Eyrie)");
+			put(new Point(3434, 2889), "Nardah bank");
+			put(new Point(3316, 2867), "Agility Pyramid mine");
+			put(new Point(3171, 2910), "Desert Quarry mine");
 	    /*
 	    FELDIP HILLS/ISLE OF SOULS
 	     */
-            put(new Point(2567, 2858), "Corsair Cove bank");
-            put(new Point(2483, 2886), "Corsair Resource Area");
-            put(new Point(2468, 2842), "Myths' Guild");
-            put(new Point(2571, 2964), "Feldip Hills (aks fairy ring)");
-            put(new Point(2630, 2993), "Rantz cave");
-            put(new Point(2200, 2792), "Soul Wars south mine");
+			put(new Point(2567, 2858), "Corsair Cove bank");
+			put(new Point(2483, 2886), "Corsair Resource Area");
+			put(new Point(2468, 2842), "Myths' Guild");
+			put(new Point(2571, 2964), "Feldip Hills (aks fairy ring)");
+			put(new Point(2630, 2993), "Rantz cave");
+			put(new Point(2200, 2792), "Soul Wars south mine");
 	    /*
 	    FOSSIL ISLAND/MOS LE HARMLESS
 	     */
-            put(new Point(3818, 3801), "Fossil Island Volcanic Mine entrance");
-            put(new Point(3774, 3814), "Fossil Island rune rocks");
-            put(new Point(3686, 2969), "Mos Le'Harmless west bank");
+			put(new Point(3818, 3801), "Fossil Island Volcanic Mine entrance");
+			put(new Point(3774, 3814), "Fossil Island rune rocks");
+			put(new Point(3686, 2969), "Mos Le'Harmless west bank");
 	    /*
 	    FREMENNIK/LUNAR ISLE
 	     */
-            put(new Point(2727, 3683), "Keldagrim entrance mine");
-            put(new Point(2683, 3699), "Rellekka mine");
-            put(new Point(2393, 3814), "Jatizso mine entrance");
-            put(new Point(2375, 3832), "Neitiznot south of rune rock");
-            put(new Point(2528, 3887), "Miscellania mine (cip fairy ring)");
-            put(new Point(2139, 3938), "Lunar Isle mine entrance");
+			put(new Point(2727, 3683), "Keldagrim entrance mine");
+			put(new Point(2683, 3699), "Rellekka mine");
+			put(new Point(2393, 3814), "Jatizso mine entrance");
+			put(new Point(2375, 3832), "Neitiznot south of rune rock");
+			put(new Point(2528, 3887), "Miscellania mine (cip fairy ring)");
+			put(new Point(2139, 3938), "Lunar Isle mine entrance");
 	    /*
 	    KANDARIN
 	     */
-            put(new Point(2602, 3086), "Yanille bank");
-            put(new Point(2624, 3141), "Port Khazard mine");
-            put(new Point(2608, 3233), "Ardougne Monastery");
-            put(new Point(2705, 3333), "South of Legends' Guild");
-            put(new Point(2804, 3434), "Catherby bank");
-            put(new Point(2589, 3478), "Coal Trucks west of Seers'");
+			put(new Point(2602, 3086), "Yanille bank");
+			put(new Point(2624, 3141), "Port Khazard mine");
+			put(new Point(2608, 3233), "Ardougne Monastery");
+			put(new Point(2705, 3333), "South of Legends' Guild");
+			put(new Point(2804, 3434), "Catherby bank");
+			put(new Point(2589, 3478), "Coal Trucks west of Seers'");
 	    /*
 	    KOUREND
 	     */
-            put(new Point(1778, 3493), "Hosidius mine");
-            put(new Point(1769, 3709), "Port Piscarilius mine in Kourend");
-            put(new Point(1597, 3648), "Shayzien mine south of Kourend Castle");
-            put(new Point(1534, 3747), "South Lovakengj bank");
-            put(new Point(1437, 3840), "Lovakite mine");
-            put(new Point(1760, 3853), "Arceuus dense essence mine");
+			put(new Point(1778, 3493), "Hosidius mine");
+			put(new Point(1769, 3709), "Port Piscarilius mine in Kourend");
+			put(new Point(1597, 3648), "Shayzien mine south of Kourend Castle");
+			put(new Point(1534, 3747), "South Lovakengj bank");
+			put(new Point(1437, 3840), "Lovakite mine");
+			put(new Point(1760, 3853), "Arceuus dense essence mine");
 	    /*
 	    KEBOS LOWLANDS
 	     */
-            put(new Point(1322, 3816), "Mount Karuulm bank");
-            put(new Point(1279, 3817), "Mount Karuulm mine");
-            put(new Point(1210, 3651), "Kebos Swamp mine");
-            put(new Point(1258, 3564), "Chambers of Xeric bank");
+			put(new Point(1322, 3816), "Mount Karuulm bank");
+			put(new Point(1279, 3817), "Mount Karuulm mine");
+			put(new Point(1210, 3651), "Kebos Swamp mine");
+			put(new Point(1258, 3564), "Chambers of Xeric bank");
 	    /*
 	    MISTHALIN
 	     */
-            put(new Point(3258, 3408), "Varrock east bank");
-            put(new Point(3290, 3353), "Southeast Varrock mine");
-            put(new Point(3175, 3362), "Champions' Guild mine");
-            put(new Point(3094, 3235), "Draynor Village");
-            put(new Point(3153, 3150), "West Lumbridge Swamp mine");
-            put(new Point(3230, 3155), "East Lumbridge Swamp mine");
+			put(new Point(3258, 3408), "Varrock east bank");
+			put(new Point(3290, 3353), "Southeast Varrock mine");
+			put(new Point(3175, 3362), "Champions' Guild mine");
+			put(new Point(3094, 3235), "Draynor Village");
+			put(new Point(3153, 3150), "West Lumbridge Swamp mine");
+			put(new Point(3230, 3155), "East Lumbridge Swamp mine");
 	    /*
 	    MORYTANIA
 	     */
-            put(new Point(3635, 3340), "Darkmeyer ess. mine entrance");
-            put(new Point(3650, 3214), "Theatre of Blood bank");
-            put(new Point(3505, 3485), "Canifis bank");
-            put(new Point(3500, 3219), "Burgh de Rott bank");
-            put(new Point(3451, 3233), "Abandoned Mine west of Burgh");
+			put(new Point(3635, 3340), "Darkmeyer ess. mine entrance");
+			put(new Point(3650, 3214), "Theatre of Blood bank");
+			put(new Point(3505, 3485), "Canifis bank");
+			put(new Point(3500, 3219), "Burgh de Rott bank");
+			put(new Point(3451, 3233), "Abandoned Mine west of Burgh");
 	    /*
 	    PISCATORIS/GNOME STRONGHOLD
 	     */
-            put(new Point(2444, 3490), "West of Grand Tree");
-            put(new Point(2448, 3436), "Gnome Stronghold spirit tree");
-            put(new Point(2341, 3635), "Piscatoris (akq fairy ring)");
+			put(new Point(2444, 3490), "West of Grand Tree");
+			put(new Point(2448, 3436), "Gnome Stronghold spirit tree");
+			put(new Point(2341, 3635), "Piscatoris (akq fairy ring)");
 	    /*
 	    TIRANNWN
 	     */
-            put(new Point(2329, 3163), "Lletya");
-            put(new Point(2269, 3158), "Isafdar runite rocks");
-            put(new Point(3274, 6055), "Prifddinas Zalcano entrance");
-            put(new Point(2318, 3269), "Arandar mine north of Lletya");
-            put(new Point(2173, 3409), "Mynydd nw of Prifddinas");
+			put(new Point(2329, 3163), "Lletya");
+			put(new Point(2269, 3158), "Isafdar runite rocks");
+			put(new Point(3274, 6055), "Prifddinas Zalcano entrance");
+			put(new Point(2318, 3269), "Arandar mine north of Lletya");
+			put(new Point(2173, 3409), "Mynydd nw of Prifddinas");
 	    /*
 	    WILDERNESS
 	     */
-            put(new Point(3108, 3569), "Mage of Zamorak mine (lvl 7 Wildy)");
-            put(new Point(3018, 3593), "Skeleton mine (lvl 10 Wildy)");
-            put(new Point(3093, 3756), "Hobgoblin mine (lvl 30 Wildy)");
-            put(new Point(3057, 3887), "Lava maze runite mine (lvl 46 Wildy)");
-            put(new Point(3049, 3940), "Pirates' Hideout (lvl 53 Wildy)");
-            put(new Point(3091, 3962), "Mage Arena bank (lvl 56 Wildy)");
-            put(new Point(3188, 3932), "Wilderness Resource Area");
-        }
-    };
+			put(new Point(3108, 3569), "Mage of Zamorak mine (lvl 7 Wildy)");
+			put(new Point(3018, 3593), "Skeleton mine (lvl 10 Wildy)");
+			put(new Point(3093, 3756), "Hobgoblin mine (lvl 30 Wildy)");
+			put(new Point(3057, 3887), "Lava maze runite mine (lvl 46 Wildy)");
+			put(new Point(3049, 3940), "Pirates' Hideout (lvl 53 Wildy)");
+			put(new Point(3091, 3962), "Mage Arena bank (lvl 56 Wildy)");
+			put(new Point(3188, 3932), "Wilderness Resource Area");
+		}
+	};
 }

--- a/src/main/java/com/starcallingassist/StarCallingAssistConfig.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistConfig.java
@@ -2,331 +2,413 @@ package com.starcallingassist;
 
 import com.starcallingassist.sidepanel.constants.RegionKeyName;
 import com.starcallingassist.sidepanel.constants.TotalLevelType;
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
-import net.runelite.client.config.Range;
-import net.runelite.client.config.Units;
+import net.runelite.client.config.*;
 
 @ConfigGroup("starcallingassistplugin")
 public interface StarCallingAssistConfig extends Config
 {
     @ConfigItem(
-	    keyName = "endpoint",
-	    position = 0,
-	    name = "Endpoint",
-	    description = "Endpoint to post calls to and fetch calls from")
+        keyName = "endpoint",
+        position = 0,
+        name = "Endpoint",
+        description = "Endpoint to post calls to and fetch calls from")
     default String getEndpoint()
     {
-	return "https://public.starminers.site/crowdsource";
+        return "https://public.starminers.site/crowdsource";
     }
 
     @ConfigItem(
-	    keyName = "authorization",
-	    position = 1,
-	    name = "Authorization",
-	    description = "Used to set the http authorization header.")
+        keyName = "authorization",
+        position = 1,
+        name = "Authorization",
+        description = "Used to set the http authorization header.")
     default String getAuthorization()
     {
-	return "";
+        return "";
     }
 
     @ConfigSection(
-	    name = "Caller Settings",
-	    description = "Settings to configure the caller part of the plugin.",
-	    position = 2
+        name = "Caller Settings",
+        description = "Settings to configure the caller part of the plugin.",
+        position = 2
     )
     String callerSection = "Caller Settings";
 
     @ConfigItem(
-	    keyName = "includeIgn",
-	    name = "Send in-game name",
-	    description = "Includes your in-game name with your calls. This is required if you want the stars you find " +
-			  "to count towards your called stars total.",
-	    position = 3,
-	    section = callerSection
+        keyName = "includeIgn",
+        name = "Send in-game name",
+        description = "Includes your in-game name with your calls. This is required if you want the stars you find " +
+                      "to count towards your called stars total.",
+        position = 3,
+        section = callerSection
     )
-    default boolean includeIgn() {return false;}
+    default boolean includeIgn()
+    {
+        return false;
+    }
 
     @ConfigItem(
-	    keyName = "autoCall",
-	    name = "Auto call stars",
-	    description = "Automatically call stars as they appear or fully depletes",
-	    position = 4,
-	    section = callerSection
+        keyName = "autoCall",
+        name = "Auto call stars",
+        description = "Automatically call stars as they appear or fully depletes",
+        position = 4,
+        section = callerSection
     )
-    default boolean autoCall() {return true;}
+    default boolean autoCall()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = "updateStar",
-	    name = "Auto update stars",
-	    description = "Posts a new call when the tier of a star changes (Auto call must be enabled)",
-	    position = 5,
-	    section = callerSection
+        keyName = "updateStar",
+        name = "Auto update stars",
+        description = "Posts a new call when the tier of a star changes (Auto call must be enabled)",
+        position = 5,
+        section = callerSection
     )
-    default boolean updateStar() {return true;}
+    default boolean updateStar()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = "chatMessages",
-	    name = "Display chat messages",
-	    description = "Display chat messages on successful calls, unsuccessful calls and other errors",
-	    position = 6,
-	    section = callerSection
+        keyName = "chatMessages",
+        name = "Display chat messages",
+        description = "Display chat messages on successful calls, unsuccessful calls and other errors",
+        position = 6,
+        section = callerSection
     )
-    default boolean chatMessages() {return true;}
+    default boolean chatMessages()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = "callHorn",
-	    name = "Call Button",
-	    description = "Enables a button which can be used to call a star.",
-	    position = 7,
-	    section = callerSection
+        keyName = "callHorn",
+        name = "Call Button",
+        description = "Enables a button which can be used to call a star.",
+        position = 7,
+        section = callerSection
     )
-    default boolean callHorn() {return false;}
+    default boolean callHorn()
+    {
+        return false;
+    }
 
     @ConfigSection(
-	    name = "Star Panel Settings",
-	    description = "Settings to configure side panel displaying active stars.",
-	    position = 8
+        name = "Star Panel Settings",
+        description = "Settings to configure side panel displaying active stars.",
+        position = 8
     )
     String panelSection = "Star Panel Settings";
 
     @ConfigItem(
-	    keyName = "estimateTier",
-	    name = "Estimate Tier",
-	    description = "Estimates the current tier of stars in the list.",
-	    position = 9,
-	    section = panelSection
+        keyName = "estimateTier",
+        name = "Estimate Tier",
+        description = "Estimates the current tier of stars in the list.",
+        position = 9,
+        section = panelSection
     )
-    default boolean estimateTier() {return true;}
+    default boolean estimateTier()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = "minTier",
-	    name = "Minimum Tier",
-	    description = "Lowest tier of stars to be displayed in the side-panel.",
-	    position = 10,
-	    section = panelSection
+        keyName = "minTier",
+        name = "Minimum Tier",
+        description = "Lowest tier of stars to be displayed in the side-panel.",
+        position = 10,
+        section = panelSection
     )
     @Range(
-	    min = 1,
-	    max = 9
+        min = 1,
+        max = 9
     )
-    default int minTier() {return 1;}
+    default int minTier()
+    {
+        return 1;
+    }
 
     @ConfigItem(
-	    keyName = "maxTier",
-	    name = "Maximum Tier",
-	    description = "Highest tier of stars to be displayed in the side-panel.",
-	    position = 11,
-	    section = panelSection
+        keyName = "maxTier",
+        name = "Maximum Tier",
+        description = "Highest tier of stars to be displayed in the side-panel.",
+        position = 11,
+        section = panelSection
     )
     @Range(
-	    min = 1,
-	    max = 9
+        min = 1,
+        max = 9
     )
-    default int maxTier() {return 9;}
+    default int maxTier()
+    {
+        return 9;
+    }
 
     @ConfigItem(
-	    keyName = "minDeadTime",
-	    name = "Min. Dead Time",
-	    description = "Hides stars that are estimated to be depleted in less than the specified amount of minutes",
-	    position = 12,
-	    section = panelSection
+        keyName = "minDeadTime",
+        name = "Min. Dead Time",
+        description = "Hides stars that are estimated to be depleted in less than the specified amount of minutes",
+        position = 12,
+        section = panelSection
     )
     @Range(
-	    min = -90,
-	    max = 90
+        min = -90,
+        max = 90
     )
     @Units(
-	    value = Units.MINUTES
+        value = Units.MINUTES
     )
-    default int minDeadTime() {return -5;}
+    default int minDeadTime()
+    {
+        return -5;
+    }
 
     @ConfigItem(
-	    keyName = "showF2P",
-	    name = "Show F2P",
-	    description = "Show or hide f2p worlds.",
-	    position = 13,
-	    section = panelSection
+        keyName = "showF2P",
+        name = "Show F2P",
+        description = "Show or hide f2p worlds.",
+        position = 13,
+        section = panelSection
     )
-    default boolean showF2P() {return true;}
+    default boolean showF2P()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = "showMembers",
-	    name = "Show Members",
-	    description = "Show or hide members worlds.",
-	    position = 14,
-	    section = panelSection
+        keyName = "showMembers",
+        name = "Show Members",
+        description = "Show or hide members worlds.",
+        position = 14,
+        section = panelSection
     )
-    default boolean showMembers() {return true;}
+    default boolean showMembers()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = "showPvp",
-	    name = "Show PVP",
-	    description = "Show or hide PVP worlds.",
-	    position = 15,
-	    section = panelSection
+        keyName = "showPvp",
+        name = "Show PVP",
+        description = "Show or hide PVP worlds.",
+        position = 15,
+        section = panelSection
     )
-    default boolean showPvp() {return false;}
+    default boolean showPvp()
+    {
+        return false;
+    }
 
     @ConfigItem(
-	    keyName = "showHighRisk",
-	    name = "Show High-Risk",
-	    description = "Show or hide high-risk worlds.",
-	    position = 16,
-	    section = panelSection
+        keyName = "showHighRisk",
+        name = "Show High-Risk",
+        description = "Show or hide high-risk worlds.",
+        position = 16,
+        section = panelSection
     )
-    default boolean showHighRisk() {return true;}
+    default boolean showHighRisk()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = "totalLevelType",
-	    name = "Max total world",
-	    description = "Hides worlds with a total level requirement higher than this.",
-	    position = 17,
-	    section = panelSection
+        keyName = "totalLevelType",
+        name = "Max total world",
+        description = "Hides worlds with a total level requirement higher than this.",
+        position = 17,
+        section = panelSection
     )
-    default TotalLevelType totalLevelType() { return TotalLevelType.TOTAL_2200; }
+    default TotalLevelType totalLevelType()
+    {
+        return TotalLevelType.TOTAL_2200;
+    }
 
     @ConfigSection(
-	    name = "Region Toggles",
-	    description = "Toggle regions to be displayed in the side-panel",
-	    position = 18
+        name = "Region Toggles",
+        description = "Toggle regions to be displayed in the side-panel",
+        position = 18
     )
     String regionSection = "Region Toggles";
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_ASGARNIA,
-	    name = "Asgarnia",
-	    description = "Show or hide this region.",
-	    position = 19,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_ASGARNIA,
+        name = "Asgarnia",
+        description = "Show or hide this region.",
+        position = 19,
+        section = regionSection
     )
-    default boolean asgarnia() {return true;}
+    default boolean asgarnia()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_KARAMJA,
-	    name = "Crandor/Karamja",
-	    description = "Show or hide this region.",
-	    position = 20,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_KARAMJA,
+        name = "Crandor/Karamja",
+        description = "Show or hide this region.",
+        position = 20,
+        section = regionSection
     )
-    default boolean karamja() {return true;}
+    default boolean karamja()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_FELDIP,
-	    name = "Feldip Hills/Isle Of Souls",
-	    description = "Show or hide this region.",
-	    position = 21,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_FELDIP,
+        name = "Feldip Hills/Isle Of Souls",
+        description = "Show or hide this region.",
+        position = 21,
+        section = regionSection
     )
-    default boolean feldip() {return true;}
+    default boolean feldip()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_FOSSIL,
-	    name = "Fossil Island/Mos Le Harmless",
-	    description = "Show or hide this region.",
-	    position = 22,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_FOSSIL,
+        name = "Fossil Island/Mos Le Harmless",
+        description = "Show or hide this region.",
+        position = 22,
+        section = regionSection
     )
-    default boolean fossil() {return true;}
+    default boolean fossil()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_FREMMENIK,
-	    name = "Fremmenik/Lunar Isle",
-	    description = "Show or hide this region.",
-	    position = 23,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_FREMMENIK,
+        name = "Fremmenik/Lunar Isle",
+        description = "Show or hide this region.",
+        position = 23,
+        section = regionSection
     )
-    default boolean fremmenik() {return true;}
+    default boolean fremmenik()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_KOUREND,
-	    name = "Kourend",
-	    description = "Show or hide this region.",
-	    position = 24,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_KOUREND,
+        name = "Kourend",
+        description = "Show or hide this region.",
+        position = 24,
+        section = regionSection
     )
-    default boolean kourend() {return true;}
+    default boolean kourend()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_KANDARIN,
-	    name = "Kandarin",
-	    description = "Show or hide this region.",
-	    position = 25,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_KANDARIN,
+        name = "Kandarin",
+        description = "Show or hide this region.",
+        position = 25,
+        section = regionSection
     )
-    default boolean kandarin() {return true;}
+    default boolean kandarin()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_KEBOS,
-	    name = "Kebos Lowlands",
-	    description = "Show or hide this region.",
-	    position = 26,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_KEBOS,
+        name = "Kebos Lowlands",
+        description = "Show or hide this region.",
+        position = 26,
+        section = regionSection
     )
-    default boolean kebos() {return true;}
+    default boolean kebos()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_DESERT,
-	    name = "Desert",
-	    description = "Show or hide this region.",
-	    position = 27,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_DESERT,
+        name = "Desert",
+        description = "Show or hide this region.",
+        position = 27,
+        section = regionSection
     )
-    default boolean desert() {return true;}
+    default boolean desert()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_MISTHALIN,
-	    name = "Misthalin",
-	    description = "Show or hide this region.",
-	    position = 28,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_MISTHALIN,
+        name = "Misthalin",
+        description = "Show or hide this region.",
+        position = 28,
+        section = regionSection
     )
-    default boolean misthalin() {return true;}
+    default boolean misthalin()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_MORYTANIA,
-	    name = "Morytania",
-	    description = "Show or hide this region.",
-	    position = 29,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_MORYTANIA,
+        name = "Morytania",
+        description = "Show or hide this region.",
+        position = 29,
+        section = regionSection
     )
-    default boolean morytania() {return true;}
+    default boolean morytania()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_GNOME,
-	    name = "Piscatoris/Gnome Stronghold",
-	    description = "Show or hide this region.",
-	    position = 30,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_GNOME,
+        name = "Piscatoris/Gnome Stronghold",
+        description = "Show or hide this region.",
+        position = 30,
+        section = regionSection
     )
-    default boolean gnome() {return true;}
+    default boolean gnome()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_TIRANNWN,
-	    name = "Tirannwn",
-	    description = "Show or hide this region.",
-	    position = 31,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_TIRANNWN,
+        name = "Tirannwn",
+        description = "Show or hide this region.",
+        position = 31,
+        section = regionSection
     )
-    default boolean tirannwn() {return true;}
+    default boolean tirannwn()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_WILDERNESS,
-	    name = "Wilderness",
-	    description = "Show or hide this region.",
-	    position = 32,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_WILDERNESS,
+        name = "Wilderness",
+        description = "Show or hide this region.",
+        position = 32,
+        section = regionSection
     )
-    default boolean wilderness() {return true;}
+    default boolean wilderness()
+    {
+        return true;
+    }
 
     @ConfigItem(
-	    keyName = RegionKeyName.KEY_UNKNOWN,
-	    name = "Unknown/Unscoped",
-	    description = "Show or hide stars where the region is unscoped.",
-	    position = 33,
-	    section = regionSection
+        keyName = RegionKeyName.KEY_UNKNOWN,
+        name = "Unknown/Unscoped",
+        description = "Show or hide stars where the region is unscoped.",
+        position = 33,
+        section = regionSection
     )
-    default boolean unknown() {return true;}
+    default boolean unknown()
+    {
+        return true;
+    }
 }

--- a/src/main/java/com/starcallingassist/StarCallingAssistConfig.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistConfig.java
@@ -12,408 +12,408 @@ import net.runelite.client.config.Units;
 @ConfigGroup("starcallingassistplugin")
 public interface StarCallingAssistConfig extends Config
 {
-    @ConfigItem(
-        keyName = "endpoint",
-        position = 0,
-        name = "Endpoint",
-        description = "Endpoint to post calls to and fetch calls from")
-    default String getEndpoint()
-    {
-        return "https://public.starminers.site/crowdsource";
-    }
+	@ConfigItem(
+		keyName = "endpoint",
+		position = 0,
+		name = "Endpoint",
+		description = "Endpoint to post calls to and fetch calls from")
+	default String getEndpoint()
+	{
+		return "https://public.starminers.site/crowdsource";
+	}
 
-    @ConfigItem(
-        keyName = "authorization",
-        position = 1,
-        name = "Authorization",
-        description = "Used to set the http authorization header.")
-    default String getAuthorization()
-    {
-        return "";
-    }
+	@ConfigItem(
+		keyName = "authorization",
+		position = 1,
+		name = "Authorization",
+		description = "Used to set the http authorization header.")
+	default String getAuthorization()
+	{
+		return "";
+	}
 
-    @ConfigSection(
-        name = "Caller Settings",
-        description = "Settings to configure the caller part of the plugin.",
-        position = 2
-    )
-    String callerSection = "Caller Settings";
+	@ConfigSection(
+		name = "Caller Settings",
+		description = "Settings to configure the caller part of the plugin.",
+		position = 2
+	)
+	String callerSection = "Caller Settings";
 
-    @ConfigItem(
-        keyName = "includeIgn",
-        name = "Send in-game name",
-        description = "Includes your in-game name with your calls. This is required if you want the stars you find " +
-                      "to count towards your called stars total.",
-        position = 3,
-        section = callerSection
-    )
-    default boolean includeIgn()
-    {
-        return false;
-    }
+	@ConfigItem(
+		keyName = "includeIgn",
+		name = "Send in-game name",
+		description = "Includes your in-game name with your calls. This is required if you want the stars you find " +
+			"to count towards your called stars total.",
+		position = 3,
+		section = callerSection
+	)
+	default boolean includeIgn()
+	{
+		return false;
+	}
 
-    @ConfigItem(
-        keyName = "autoCall",
-        name = "Auto call stars",
-        description = "Automatically call stars as they appear or fully depletes",
-        position = 4,
-        section = callerSection
-    )
-    default boolean autoCall()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "autoCall",
+		name = "Auto call stars",
+		description = "Automatically call stars as they appear or fully depletes",
+		position = 4,
+		section = callerSection
+	)
+	default boolean autoCall()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = "updateStar",
-        name = "Auto update stars",
-        description = "Posts a new call when the tier of a star changes (Auto call must be enabled)",
-        position = 5,
-        section = callerSection
-    )
-    default boolean updateStar()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "updateStar",
+		name = "Auto update stars",
+		description = "Posts a new call when the tier of a star changes (Auto call must be enabled)",
+		position = 5,
+		section = callerSection
+	)
+	default boolean updateStar()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = "chatMessages",
-        name = "Display chat messages",
-        description = "Display chat messages on successful calls, unsuccessful calls and other errors",
-        position = 6,
-        section = callerSection
-    )
-    default boolean chatMessages()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "chatMessages",
+		name = "Display chat messages",
+		description = "Display chat messages on successful calls, unsuccessful calls and other errors",
+		position = 6,
+		section = callerSection
+	)
+	default boolean chatMessages()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = "callHorn",
-        name = "Call Button",
-        description = "Enables a button which can be used to call a star.",
-        position = 7,
-        section = callerSection
-    )
-    default boolean callHorn()
-    {
-        return false;
-    }
+	@ConfigItem(
+		keyName = "callHorn",
+		name = "Call Button",
+		description = "Enables a button which can be used to call a star.",
+		position = 7,
+		section = callerSection
+	)
+	default boolean callHorn()
+	{
+		return false;
+	}
 
-    @ConfigSection(
-        name = "Star Panel Settings",
-        description = "Settings to configure side panel displaying active stars.",
-        position = 8
-    )
-    String panelSection = "Star Panel Settings";
+	@ConfigSection(
+		name = "Star Panel Settings",
+		description = "Settings to configure side panel displaying active stars.",
+		position = 8
+	)
+	String panelSection = "Star Panel Settings";
 
-    @ConfigItem(
-        keyName = "estimateTier",
-        name = "Estimate Tier",
-        description = "Estimates the current tier of stars in the list.",
-        position = 9,
-        section = panelSection
-    )
-    default boolean estimateTier()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "estimateTier",
+		name = "Estimate Tier",
+		description = "Estimates the current tier of stars in the list.",
+		position = 9,
+		section = panelSection
+	)
+	default boolean estimateTier()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = "minTier",
-        name = "Minimum Tier",
-        description = "Lowest tier of stars to be displayed in the side-panel.",
-        position = 10,
-        section = panelSection
-    )
-    @Range(
-        min = 1,
-        max = 9
-    )
-    default int minTier()
-    {
-        return 1;
-    }
+	@ConfigItem(
+		keyName = "minTier",
+		name = "Minimum Tier",
+		description = "Lowest tier of stars to be displayed in the side-panel.",
+		position = 10,
+		section = panelSection
+	)
+	@Range(
+		min = 1,
+		max = 9
+	)
+	default int minTier()
+	{
+		return 1;
+	}
 
-    @ConfigItem(
-        keyName = "maxTier",
-        name = "Maximum Tier",
-        description = "Highest tier of stars to be displayed in the side-panel.",
-        position = 11,
-        section = panelSection
-    )
-    @Range(
-        min = 1,
-        max = 9
-    )
-    default int maxTier()
-    {
-        return 9;
-    }
+	@ConfigItem(
+		keyName = "maxTier",
+		name = "Maximum Tier",
+		description = "Highest tier of stars to be displayed in the side-panel.",
+		position = 11,
+		section = panelSection
+	)
+	@Range(
+		min = 1,
+		max = 9
+	)
+	default int maxTier()
+	{
+		return 9;
+	}
 
-    @ConfigItem(
-        keyName = "minDeadTime",
-        name = "Min. Dead Time",
-        description = "Hides stars that are estimated to be depleted in less than the specified amount of minutes",
-        position = 12,
-        section = panelSection
-    )
-    @Range(
-        min = -90,
-        max = 90
-    )
-    @Units(
-        value = Units.MINUTES
-    )
-    default int minDeadTime()
-    {
-        return -5;
-    }
+	@ConfigItem(
+		keyName = "minDeadTime",
+		name = "Min. Dead Time",
+		description = "Hides stars that are estimated to be depleted in less than the specified amount of minutes",
+		position = 12,
+		section = panelSection
+	)
+	@Range(
+		min = -90,
+		max = 90
+	)
+	@Units(
+		value = Units.MINUTES
+	)
+	default int minDeadTime()
+	{
+		return -5;
+	}
 
-    @ConfigItem(
-        keyName = "showF2P",
-        name = "Show F2P",
-        description = "Show or hide f2p worlds.",
-        position = 13,
-        section = panelSection
-    )
-    default boolean showF2P()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "showF2P",
+		name = "Show F2P",
+		description = "Show or hide f2p worlds.",
+		position = 13,
+		section = panelSection
+	)
+	default boolean showF2P()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = "showMembers",
-        name = "Show Members",
-        description = "Show or hide members worlds.",
-        position = 14,
-        section = panelSection
-    )
-    default boolean showMembers()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "showMembers",
+		name = "Show Members",
+		description = "Show or hide members worlds.",
+		position = 14,
+		section = panelSection
+	)
+	default boolean showMembers()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = "showPvp",
-        name = "Show PVP",
-        description = "Show or hide PVP worlds.",
-        position = 15,
-        section = panelSection
-    )
-    default boolean showPvp()
-    {
-        return false;
-    }
+	@ConfigItem(
+		keyName = "showPvp",
+		name = "Show PVP",
+		description = "Show or hide PVP worlds.",
+		position = 15,
+		section = panelSection
+	)
+	default boolean showPvp()
+	{
+		return false;
+	}
 
-    @ConfigItem(
-        keyName = "showHighRisk",
-        name = "Show High-Risk",
-        description = "Show or hide high-risk worlds.",
-        position = 16,
-        section = panelSection
-    )
-    default boolean showHighRisk()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = "showHighRisk",
+		name = "Show High-Risk",
+		description = "Show or hide high-risk worlds.",
+		position = 16,
+		section = panelSection
+	)
+	default boolean showHighRisk()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = "totalLevelType",
-        name = "Max total world",
-        description = "Hides worlds with a total level requirement higher than this.",
-        position = 17,
-        section = panelSection
-    )
-    default TotalLevelType totalLevelType()
-    {
-        return TotalLevelType.TOTAL_2200;
-    }
+	@ConfigItem(
+		keyName = "totalLevelType",
+		name = "Max total world",
+		description = "Hides worlds with a total level requirement higher than this.",
+		position = 17,
+		section = panelSection
+	)
+	default TotalLevelType totalLevelType()
+	{
+		return TotalLevelType.TOTAL_2200;
+	}
 
-    @ConfigSection(
-        name = "Region Toggles",
-        description = "Toggle regions to be displayed in the side-panel",
-        position = 18
-    )
-    String regionSection = "Region Toggles";
+	@ConfigSection(
+		name = "Region Toggles",
+		description = "Toggle regions to be displayed in the side-panel",
+		position = 18
+	)
+	String regionSection = "Region Toggles";
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_ASGARNIA,
-        name = "Asgarnia",
-        description = "Show or hide this region.",
-        position = 19,
-        section = regionSection
-    )
-    default boolean asgarnia()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_ASGARNIA,
+		name = "Asgarnia",
+		description = "Show or hide this region.",
+		position = 19,
+		section = regionSection
+	)
+	default boolean asgarnia()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_KARAMJA,
-        name = "Crandor/Karamja",
-        description = "Show or hide this region.",
-        position = 20,
-        section = regionSection
-    )
-    default boolean karamja()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_KARAMJA,
+		name = "Crandor/Karamja",
+		description = "Show or hide this region.",
+		position = 20,
+		section = regionSection
+	)
+	default boolean karamja()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_FELDIP,
-        name = "Feldip Hills/Isle Of Souls",
-        description = "Show or hide this region.",
-        position = 21,
-        section = regionSection
-    )
-    default boolean feldip()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_FELDIP,
+		name = "Feldip Hills/Isle Of Souls",
+		description = "Show or hide this region.",
+		position = 21,
+		section = regionSection
+	)
+	default boolean feldip()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_FOSSIL,
-        name = "Fossil Island/Mos Le Harmless",
-        description = "Show or hide this region.",
-        position = 22,
-        section = regionSection
-    )
-    default boolean fossil()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_FOSSIL,
+		name = "Fossil Island/Mos Le Harmless",
+		description = "Show or hide this region.",
+		position = 22,
+		section = regionSection
+	)
+	default boolean fossil()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_FREMMENIK,
-        name = "Fremmenik/Lunar Isle",
-        description = "Show or hide this region.",
-        position = 23,
-        section = regionSection
-    )
-    default boolean fremmenik()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_FREMMENIK,
+		name = "Fremmenik/Lunar Isle",
+		description = "Show or hide this region.",
+		position = 23,
+		section = regionSection
+	)
+	default boolean fremmenik()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_KOUREND,
-        name = "Kourend",
-        description = "Show or hide this region.",
-        position = 24,
-        section = regionSection
-    )
-    default boolean kourend()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_KOUREND,
+		name = "Kourend",
+		description = "Show or hide this region.",
+		position = 24,
+		section = regionSection
+	)
+	default boolean kourend()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_KANDARIN,
-        name = "Kandarin",
-        description = "Show or hide this region.",
-        position = 25,
-        section = regionSection
-    )
-    default boolean kandarin()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_KANDARIN,
+		name = "Kandarin",
+		description = "Show or hide this region.",
+		position = 25,
+		section = regionSection
+	)
+	default boolean kandarin()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_KEBOS,
-        name = "Kebos Lowlands",
-        description = "Show or hide this region.",
-        position = 26,
-        section = regionSection
-    )
-    default boolean kebos()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_KEBOS,
+		name = "Kebos Lowlands",
+		description = "Show or hide this region.",
+		position = 26,
+		section = regionSection
+	)
+	default boolean kebos()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_DESERT,
-        name = "Desert",
-        description = "Show or hide this region.",
-        position = 27,
-        section = regionSection
-    )
-    default boolean desert()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_DESERT,
+		name = "Desert",
+		description = "Show or hide this region.",
+		position = 27,
+		section = regionSection
+	)
+	default boolean desert()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_MISTHALIN,
-        name = "Misthalin",
-        description = "Show or hide this region.",
-        position = 28,
-        section = regionSection
-    )
-    default boolean misthalin()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_MISTHALIN,
+		name = "Misthalin",
+		description = "Show or hide this region.",
+		position = 28,
+		section = regionSection
+	)
+	default boolean misthalin()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_MORYTANIA,
-        name = "Morytania",
-        description = "Show or hide this region.",
-        position = 29,
-        section = regionSection
-    )
-    default boolean morytania()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_MORYTANIA,
+		name = "Morytania",
+		description = "Show or hide this region.",
+		position = 29,
+		section = regionSection
+	)
+	default boolean morytania()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_GNOME,
-        name = "Piscatoris/Gnome Stronghold",
-        description = "Show or hide this region.",
-        position = 30,
-        section = regionSection
-    )
-    default boolean gnome()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_GNOME,
+		name = "Piscatoris/Gnome Stronghold",
+		description = "Show or hide this region.",
+		position = 30,
+		section = regionSection
+	)
+	default boolean gnome()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_TIRANNWN,
-        name = "Tirannwn",
-        description = "Show or hide this region.",
-        position = 31,
-        section = regionSection
-    )
-    default boolean tirannwn()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_TIRANNWN,
+		name = "Tirannwn",
+		description = "Show or hide this region.",
+		position = 31,
+		section = regionSection
+	)
+	default boolean tirannwn()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_WILDERNESS,
-        name = "Wilderness",
-        description = "Show or hide this region.",
-        position = 32,
-        section = regionSection
-    )
-    default boolean wilderness()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_WILDERNESS,
+		name = "Wilderness",
+		description = "Show or hide this region.",
+		position = 32,
+		section = regionSection
+	)
+	default boolean wilderness()
+	{
+		return true;
+	}
 
-    @ConfigItem(
-        keyName = RegionKeyName.KEY_UNKNOWN,
-        name = "Unknown/Unscoped",
-        description = "Show or hide stars where the region is unscoped.",
-        position = 33,
-        section = regionSection
-    )
-    default boolean unknown()
-    {
-        return true;
-    }
+	@ConfigItem(
+		keyName = RegionKeyName.KEY_UNKNOWN,
+		name = "Unknown/Unscoped",
+		description = "Show or hide stars where the region is unscoped.",
+		position = 33,
+		section = regionSection
+	)
+	default boolean unknown()
+	{
+		return true;
+	}
 }

--- a/src/main/java/com/starcallingassist/StarCallingAssistConfig.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistConfig.java
@@ -2,7 +2,12 @@ package com.starcallingassist;
 
 import com.starcallingassist.sidepanel.constants.RegionKeyName;
 import com.starcallingassist.sidepanel.constants.TotalLevelType;
-import net.runelite.client.config.*;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("starcallingassistplugin")
 public interface StarCallingAssistConfig extends Config

--- a/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
@@ -112,17 +112,19 @@ public class StarCallingAssistPlugin extends Plugin
     public void onGameObjectSpawned(GameObjectSpawned event)
     {
         int tier = Star.getTier(event.getGameObject().getId());
-        if (tier != -1) {
-            Star.setStar(event.getGameObject(), tier, client.getWorld());
+        if (tier == -1) {
+            return;
+        }
 
-            if (starConfig.autoCall()) {
-                if (whitinPlayerDistance()) {
-                    countMiners();
-                    prepareCall(false);
-                } else {
-                    miners = -1;
-                    prepareCall(false);
-                }
+        Star.setStar(event.getGameObject(), tier, client.getWorld());
+
+        if (starConfig.autoCall()) {
+            if (whitinPlayerDistance()) {
+                countMiners();
+                prepareCall(false);
+            } else {
+                miners = -1;
+                prepareCall(false);
             }
         }
     }
@@ -130,14 +132,16 @@ public class StarCallingAssistPlugin extends Plugin
     @Subscribe
     public void onGameObjectDespawned(GameObjectDespawned event)
     {
-        if (Star.getTier(event.getGameObject().getId()) != -1) {
-            //Causes a check for whether the star fully depleted in the next GameTick event
-            if (starConfig.autoCall()) {
-                confirmDeadLocation = event.getGameObject().getWorldLocation();
-            }
-
-            Star.removeStar();
+        if (Star.getTier(event.getGameObject().getId()) == -1) {
+            return;
         }
+
+        //Causes a check for whether the star fully depleted in the next GameTick event
+        if (starConfig.autoCall()) {
+            confirmDeadLocation = event.getGameObject().getWorldLocation();
+        }
+
+        Star.removeStar();
     }
 
     @Subscribe

--- a/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
@@ -216,7 +216,7 @@ public class StarCallingAssistPlugin extends Plugin
             return;
         }
 
-        if (event.equals("endpoint")) {
+        if (event.getKey().equals("endpoint")) {
             fetchStarData();
             return;
         }

--- a/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
@@ -2,12 +2,32 @@ package com.starcallingassist;
 
 import com.google.inject.Provides;
 import com.starcallingassist.sidepanel.SidePanel;
+import java.awt.*;
+import java.io.IOException;
+import java.time.temporal.ChronoUnit;
+import javax.inject.Inject;
+import javax.swing.*;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Player;
+import net.runelite.api.ScriptEvent;
+import net.runelite.api.SpriteID;
+import net.runelite.api.World;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.*;
-import net.runelite.api.widgets.*;
+import net.runelite.api.events.GameObjectDespawned;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.events.ResizeableChanged;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.JavaScriptCallback;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetType;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -26,12 +46,6 @@ import net.runelite.client.util.ImageUtil;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Response;
-
-import javax.inject.Inject;
-import javax.swing.*;
-import java.awt.Point;
-import java.io.IOException;
-import java.time.temporal.ChronoUnit;
 
 @PluginDescriptor(
     name = "Star Miners",

--- a/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
@@ -2,11 +2,11 @@ package com.starcallingassist;
 
 import com.google.inject.Provides;
 import com.starcallingassist.sidepanel.SidePanel;
-import java.awt.*;
+import java.awt.Point;
 import java.io.IOException;
 import java.time.temporal.ChronoUnit;
 import javax.inject.Inject;
-import javax.swing.*;
+import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -48,494 +48,555 @@ import okhttp3.Callback;
 import okhttp3.Response;
 
 @PluginDescriptor(
-    name = "Star Miners",
-    description = "Displays a list of active stars and crowdsources data about stars you find and mine",
-    tags = {"star", "shooting", "shootingstar", "meteor", "crowdsource", "crowdsourcing"}
+	name = "Star Miners",
+	description = "Displays a list of active stars and crowdsources data about stars you find and mine",
+	tags = {"star", "shooting", "shootingstar", "meteor", "crowdsource", "crowdsourcing"}
 )
 @Slf4j
 public class StarCallingAssistPlugin extends Plugin
 {
-    private static final Point BUTTON_RESIZEABLE_LOCATION = new Point(130, 150);
-    private static final Point BUTTON_FIXED_LOCATION = new Point(208, 55);
-    private static final int CALL_STAR = 5;
-    private static final int CALL_DEAD = 6;
-    private static final int CALL_PRIVATE = 7;
-    private static final int PLAYER_RENDER_DISTANCE = 13;
-
-    private Widget parent, callButton;
-    private Star lastCalledStar;
-
-    private int miners = 0, hopTarget = -1, hopAttempts = 0;
-
-    private WorldPoint confirmDeadLocation = null;
-
-    @Inject
-    private StarCallingAssistConfig starConfig;
-    @Inject
-    private ChatMessageManager chatMessageManager;
-    @Inject
-    private WorldService worldService;
-    @Inject
-    private Client client;
-    @Inject
-    private ClientThread clientThread;
-    @Inject
-    private ClientToolbar clientToolbar;
-    @Inject
-    private CallSender sender;
-
-    private SidePanel sidePanel;
-
-    private NavigationButton navButton;
-
-    @Provides
-    StarCallingAssistConfig provideConfig(ConfigManager configManager)
-    {
-        return configManager.getConfig(StarCallingAssistConfig.class);
-    }
-
-    @Override
-    protected void startUp() throws Exception
-    {
-        lastCalledStar = null;
-        parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-        clientThread.invokeLater(this::createCallButton);
-
-        sidePanel = injector.getInstance(SidePanel.class);
-        sidePanel.init();
-
-        navButton = NavigationButton.builder()
-                                    .tooltip("Star Miners")
-                                    .icon(ImageUtil.loadImageResource(getClass(), "/sminers.png"))
-                                    .panel(sidePanel)
-                                    .build();
-        clientToolbar.addNavigation(navButton);
-        navButton.setOnClick(this::fetchStarData);
-    }
-
-    @Override
-    protected void shutDown() throws Exception
-    {
-        Star.removeStar();
-        lastCalledStar = null;
-        removeCallButton();
-        clientToolbar.removeNavigation(navButton);
-    }
-
-    @Subscribe
-    public void onGameObjectSpawned(GameObjectSpawned event)
-    {
-        int tier = Star.getTier(event.getGameObject().getId());
-        if (tier == -1) {
-            return;
-        }
-
-        Star.setStar(event.getGameObject(), tier, client.getWorld());
-
-        if (starConfig.autoCall()) {
-            if (whitinPlayerDistance()) {
-                countMiners();
-                prepareCall(false);
-            } else {
-                miners = -1;
-                prepareCall(false);
-            }
-        }
-    }
-
-    @Subscribe
-    public void onGameObjectDespawned(GameObjectDespawned event)
-    {
-        if (Star.getTier(event.getGameObject().getId()) == -1) {
-            return;
-        }
-
-        //Causes a check for whether the star fully depleted in the next GameTick event
-        if (starConfig.autoCall()) {
-            confirmDeadLocation = event.getGameObject().getWorldLocation();
-        }
-
-        Star.removeStar();
-    }
-
-    @Subscribe
-    public void onGameStateChanged(GameStateChanged state)
-    {
-        if (state.getGameState() == GameState.HOPPING || state.getGameState() == GameState.LOGGING_IN) {
-            Star.removeStar();
-            removeCallButton();
-        }
-
-        if (state.getGameState() == GameState.LOGGED_IN) {
-            SwingUtilities.invokeLater(() -> sidePanel.rebuildTableRows());
-            fetchStarData();
-        }
-    }
-
-    @Subscribe
-    public void onGameTick(GameTick tick)
-    {
-        if (hopTarget != -1) {
-            performHop();
-        }
-
-        if (confirmDeadLocation != null) {
-            if (Star.getStar() == null) {
-                if (client.getLocalPlayer().getWorldLocation().distanceTo(confirmDeadLocation) <= 32) {
-                    attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, Star.getLocationName(confirmDeadLocation));
-                }
-            }
-
-            confirmDeadLocation = null;
-        }
-
-        if (Star.getStar() != null) {
-            if (client.getLocalPlayer().getWorldLocation().distanceTo(Star.getStar().location) > 32) {
-                Star.removeStar();
-            }
-
-            if (Star.getStar() != null) {
-                countMiners();
-            }
-        }
-    }
-
-    @Subscribe
-    public void onConfigChanged(ConfigChanged event)
-    {
-        if (!event.getGroup().equals("starcallingassistplugin")) {
-            return;
-        }
-
-        if (event.getKey().equals("autoCall")) {
-            if (starConfig.autoCall()) {
-                clientThread.invokeLater(() -> prepareCall(false));
-            }
-
-            return;
-        }
-
-        if (event.getKey().equals("updateStar")) {
-            if (starConfig.autoCall() && starConfig.updateStar()) {
-                clientThread.invokeLater(() -> prepareCall(false));
-            }
-
-            return;
-        }
-
-        if (event.getKey().equals("callHorn")) {
-            removeCallButton();
-            parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-            clientThread.invokeLater(this::createCallButton);
-            return;
-        }
-
-        if (event.getKey().equals("endpoint")) {
-            fetchStarData();
-            return;
-        }
-
-        if (event.getKey().equals("authorization")) {
-            sidePanel.updateInfoPanel();
-            return;
-        }
-
-        if (event.getKey().equals("estimateTier")) {
-            sidePanel.rebuildTableRows();
-            return;
-        }
-
-        sidePanel.updateTableRows();
-    }
-
-    @Subscribe
-    public void onWidgetLoaded(WidgetLoaded event)
-    {
-        if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID && (callButton == null || parent == null)) {
-            removeCallButton();
-            parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-            createCallButton();
-        }
-    }
-
-    @Subscribe
-    public void onResizeableChanged(ResizeableChanged event)
-    {
-        removeCallButton();
-        parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-        createCallButton();
-    }
-
-    @Schedule(
-        period = 30,
-        unit = ChronoUnit.SECONDS
-    )
-    public void fetchStarData()
-    {
-        if (navButton.isSelected()) {
-            sidePanel.fetchStarData();
-        }
-    }
-
-    @Schedule(
-        period = 10,
-        unit = ChronoUnit.MINUTES
-    )
-    public void fetchWorldData()
-    {
-        sidePanel.fetchWorldData();
-    }
-
-    public Client getClient()
-    {
-        return client;
-    }
-
-    public StarCallingAssistConfig getConfig()
-    {
-        return starConfig;
-    }
-
-    public void queueWorldHop(int worldId)
-    {
-        if (client.getGameState() == GameState.LOGGED_IN) {
-            hopTarget = worldId;
-            clientThread.invokeLater(() -> logHighlightedToChat("Attempting to quick-hop to world ", String.valueOf(hopTarget)));
-        }
-    }
-
-    private void performHop()
-    {
-        if (++hopAttempts >= 5) {
-            logHighlightedToChat("Unable to quick-hop to world ", String.valueOf(hopTarget));
-            hopTarget = -1;
-            hopAttempts = 0;
-            return;
-        }
-
-        if (client.getWidget(WidgetInfo.WORLD_SWITCHER_LIST) == null) {
-            client.openWorldHopper();
-            return;
-        }
-
-        World[] worldList = client.getWorldList();
-
-        if (worldList == null) {
-            return;
-        }
-
-        for (World world : worldList) {
-            if (world.getId() == hopTarget) {
-                client.hopToWorld(world);
-                break;
-            }
-        }
-
-        hopTarget = -1;
-        hopAttempts = 0;
-    }
-
-    //Credit to https://github.com/pwatts6060/star-info/. Simplified to fit our needs.
-    private void countMiners()
-    {
-        miners = 0;
-        Star star = Star.getStar();
-
-        if (!whitinPlayerDistance()) {
-            miners = -1;
-            return;
-        }
-
-        WorldArea areaH = new WorldArea(star.location.dx(-1), 4, 2);
-        WorldArea areaV = new WorldArea(star.location.dy(-1), 2, 4);
-
-        for (Player p : client.getPlayers()) {
-            if (!p.getWorldLocation().isInArea2D(areaH, areaV)) {
-                continue;
-            }
-
-            miners++;
-        }
-    }
-
-    private boolean whitinPlayerDistance()
-    {
-        return client.getLocalPlayer().getWorldLocation().distanceTo(new WorldArea(Star.getStar().location, 2, 2)) <= PLAYER_RENDER_DISTANCE;
-    }
-
-    private void createCallButton()
-    {
-        if (callButton != null || parent == null || !starConfig.callHorn()) {
-            return;
-        }
-
-        callButton = parent.createChild(WidgetType.GRAPHIC);
-        callButton.setSpriteId(SpriteID.BARBARIAN_ASSAULT_HORN_FOR_ATTACKER_ICON);
-        callButton.setOriginalWidth(20);
-        callButton.setOriginalHeight(23);
-        setCallButtonLocation();
-        callButton.setAction(4, "Call star");
-        callButton.setAction(5, "Call dead");
-        callButton.setAction(6, "Call private");
-        callButton.setHasListener(true);
-        callButton.setNoClickThrough(true);
-        callButton.setOnOpListener((JavaScriptCallback) this::callButtonClicked);
-        callButton.revalidate();
-    }
-
-    private void callButtonClicked(ScriptEvent event)
-    {
-        switch (event.getOp()) {
-            case CALL_STAR: {
-                prepareCall(true);
-                break;
-            }
-            case CALL_DEAD: {
-                attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, "dead");
-                break;
-            }
-            case CALL_PRIVATE: {
-                attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, "pdead");
-                break;
-            }
-        }
-    }
-
-    private void removeCallButton()
-    {
-        if (parent == null || callButton == null) {
-            return;
-        }
-
-        Widget[] children = parent.getChildren();
-        if (children == null || children.length <= callButton.getIndex() || !children[callButton.getIndex()].equals(callButton)) {
-            return;
-        }
-
-        children[callButton.getIndex()] = null;
-        callButton = null;
-        parent = null;
-    }
-
-    private void prepareCall(boolean manual)
-    {
-        if (Star.getStar() == null) {
-            if (manual) {
-                logToChat("Unable to find star.");
-            }
-
-            return;
-        }
-
-        if (lastCalledStar != null
-            && lastCalledStar.world == Star.getStar().world
-            && lastCalledStar.tier == Star.getStar().tier
-            && lastCalledStar.location.equals(Star.getStar().location)
-        ) {
-            if (manual) {
-                logToChat("This star has already been called.");
-            }
-
-            return;
-        }
-
-        //Won't automatically call star again if tier decreased and the updateStar option disabled
-        if (lastCalledStar != null
-            && lastCalledStar.world == Star.getStar().world
-            && lastCalledStar.location.equals(Star.getStar().location)
-            && lastCalledStar.tier > Star.getStar().tier
-            && !starConfig.updateStar() && !manual
-        ) {
-            return;
-        }
-
-        String location = Star.getLocationName(Star.getStar().location);
-        if (location.equals("unknown")) {
-            logToChat("Star location is unknown, manual call required.");
-            return;
-        }
-
-        attemptCall(client.getLocalPlayer().getName(), client.getWorld(), Star.getStar().tier, location);
-    }
-
-    private void attemptCall(String username, int world, int tier, String location)
-    {
-        try {
-            sender.sendCall(username, world, tier, location, miners, new Callback()
-            {
-                @Override
-                public void onFailure(Call call, IOException e)
-                {
-                    clientThread.invokeLater(() -> {
-                        logToChat("Unable to post call to " + starConfig.getEndpoint() + ".");
-                    });
-
-                    call.cancel();
-                }
-
-                @Override
-                public void onResponse(Call call, Response res) throws IOException
-                {
-                    if (res.isSuccessful()) {
-                        if (tier > 0) {
-                            lastCalledStar = Star.getStar();
-                        }
-
-                        clientThread.invokeLater(() -> logHighlightedToChat(
-                            "Successfully posted call: ",
-                            "W" + world + " T" + tier + " " + location + ((miners == -1 || tier == 0) ? "" : (" " + miners + " Miners"))
-                        ));
-                    } else {
-                        clientThread.invokeLater(() -> logHighlightedToChat(
-                            "Issue posting call to " + starConfig.getEndpoint() + ": ",
-                            res.message()
-                        ));
-                    }
-
-                    res.close();
-                }
-            });
-        } catch (IllegalArgumentException iae) {
-            clientThread.invokeLater(() -> {
-                logHighlightedToChat("Issue posting call to " + starConfig.getEndpoint() + ": ", "Invalid endpoint");
-            });
-        }
-    }
-
-    private void logHighlightedToChat(String normal, String highlight)
-    {
-        if (starConfig.chatMessages()) {
-            String chatMessage = new ChatMessageBuilder()
-                .append(ChatColorType.NORMAL)
-                .append(normal)
-                .append(ChatColorType.HIGHLIGHT)
-                .append(highlight)
-                .build();
-
-            chatMessageManager.queue(
-                QueuedMessage.builder()
-                             .type(ChatMessageType.CONSOLE)
-                             .runeLiteFormattedMessage(chatMessage)
-                             .build()
-            );
-        }
-    }
-
-    private void logToChat(String message)
-    {
-        if (starConfig.chatMessages()) {
-            client.addChatMessage(ChatMessageType.CONSOLE, "", message, "");
-        }
-    }
-
-    private void setCallButtonLocation()
-    {
-        if (client.isResized()) {
-            callButton.setOriginalX(BUTTON_RESIZEABLE_LOCATION.x);
-            callButton.setOriginalY(BUTTON_RESIZEABLE_LOCATION.y);
-        } else {
-            callButton.setOriginalX(BUTTON_FIXED_LOCATION.x);
-            callButton.setOriginalY(BUTTON_FIXED_LOCATION.y);
-        }
-    }
+	private static final Point BUTTON_RESIZEABLE_LOCATION = new Point(130, 150);
+	private static final Point BUTTON_FIXED_LOCATION = new Point(208, 55);
+	private static final int CALL_STAR = 5;
+	private static final int CALL_DEAD = 6;
+	private static final int CALL_PRIVATE = 7;
+	private static final int PLAYER_RENDER_DISTANCE = 13;
+
+	private Widget parent, callButton;
+	private Star lastCalledStar;
+
+	private int miners = 0, hopTarget = -1, hopAttempts = 0;
+
+	private WorldPoint confirmDeadLocation = null;
+
+	@Inject
+	private StarCallingAssistConfig starConfig;
+	@Inject
+	private ChatMessageManager chatMessageManager;
+	@Inject
+	private WorldService worldService;
+	@Inject
+	private Client client;
+	@Inject
+	private ClientThread clientThread;
+	@Inject
+	private ClientToolbar clientToolbar;
+	@Inject
+	private CallSender sender;
+
+	private SidePanel sidePanel;
+
+	private NavigationButton navButton;
+
+	@Provides
+	StarCallingAssistConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(StarCallingAssistConfig.class);
+	}
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		lastCalledStar = null;
+		parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+		clientThread.invokeLater(this::createCallButton);
+
+		sidePanel = injector.getInstance(SidePanel.class);
+		sidePanel.init();
+
+		navButton = NavigationButton.builder()
+			.tooltip("Star Miners")
+			.icon(ImageUtil.loadImageResource(getClass(), "/sminers.png"))
+			.panel(sidePanel)
+			.build();
+		clientToolbar.addNavigation(navButton);
+		navButton.setOnClick(this::fetchStarData);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		Star.removeStar();
+		lastCalledStar = null;
+		removeCallButton();
+		clientToolbar.removeNavigation(navButton);
+	}
+
+	@Subscribe
+	public void onGameObjectSpawned(GameObjectSpawned event)
+	{
+		int tier = Star.getTier(event.getGameObject().getId());
+		if (tier == -1)
+		{
+			return;
+		}
+
+		Star.setStar(event.getGameObject(), tier, client.getWorld());
+
+		if (starConfig.autoCall())
+		{
+			if (whitinPlayerDistance())
+			{
+				countMiners();
+				prepareCall(false);
+			}
+			else
+			{
+				miners = -1;
+				prepareCall(false);
+			}
+		}
+	}
+
+	@Subscribe
+	public void onGameObjectDespawned(GameObjectDespawned event)
+	{
+		if (Star.getTier(event.getGameObject().getId()) == -1)
+		{
+			return;
+		}
+
+		//Causes a check for whether the star fully depleted in the next GameTick event
+		if (starConfig.autoCall())
+		{
+			confirmDeadLocation = event.getGameObject().getWorldLocation();
+		}
+
+		Star.removeStar();
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged state)
+	{
+		if (state.getGameState() == GameState.HOPPING || state.getGameState() == GameState.LOGGING_IN)
+		{
+			Star.removeStar();
+			removeCallButton();
+		}
+
+		if (state.getGameState() == GameState.LOGGED_IN)
+		{
+			SwingUtilities.invokeLater(() -> sidePanel.rebuildTableRows());
+			fetchStarData();
+		}
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick tick)
+	{
+		if (hopTarget != -1)
+		{
+			performHop();
+		}
+
+		if (confirmDeadLocation != null)
+		{
+			if (Star.getStar() == null)
+			{
+				if (client.getLocalPlayer().getWorldLocation().distanceTo(confirmDeadLocation) <= 32)
+				{
+					attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, Star.getLocationName(confirmDeadLocation));
+				}
+			}
+
+			confirmDeadLocation = null;
+		}
+
+		if (Star.getStar() != null)
+		{
+			if (client.getLocalPlayer().getWorldLocation().distanceTo(Star.getStar().location) > 32)
+			{
+				Star.removeStar();
+			}
+
+			if (Star.getStar() != null)
+			{
+				countMiners();
+			}
+		}
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals("starcallingassistplugin"))
+		{
+			return;
+		}
+
+		if (event.getKey().equals("autoCall"))
+		{
+			if (starConfig.autoCall())
+			{
+				clientThread.invokeLater(() -> prepareCall(false));
+			}
+
+			return;
+		}
+
+		if (event.getKey().equals("updateStar"))
+		{
+			if (starConfig.autoCall() && starConfig.updateStar())
+			{
+				clientThread.invokeLater(() -> prepareCall(false));
+			}
+
+			return;
+		}
+
+		if (event.getKey().equals("callHorn"))
+		{
+			removeCallButton();
+			parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+			clientThread.invokeLater(this::createCallButton);
+			return;
+		}
+
+		if (event.getKey().equals("endpoint"))
+		{
+			fetchStarData();
+			return;
+		}
+
+		if (event.getKey().equals("authorization"))
+		{
+			sidePanel.updateInfoPanel();
+			return;
+		}
+
+		if (event.getKey().equals("estimateTier"))
+		{
+			sidePanel.rebuildTableRows();
+			return;
+		}
+
+		sidePanel.updateTableRows();
+	}
+
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID && (callButton == null || parent == null))
+		{
+			removeCallButton();
+			parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+			createCallButton();
+		}
+	}
+
+	@Subscribe
+	public void onResizeableChanged(ResizeableChanged event)
+	{
+		removeCallButton();
+		parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+		createCallButton();
+	}
+
+	@Schedule(
+		period = 30,
+		unit = ChronoUnit.SECONDS
+	)
+	public void fetchStarData()
+	{
+		if (navButton.isSelected())
+		{
+			sidePanel.fetchStarData();
+		}
+	}
+
+	@Schedule(
+		period = 10,
+		unit = ChronoUnit.MINUTES
+	)
+	public void fetchWorldData()
+	{
+		sidePanel.fetchWorldData();
+	}
+
+	public Client getClient()
+	{
+		return client;
+	}
+
+	public StarCallingAssistConfig getConfig()
+	{
+		return starConfig;
+	}
+
+	public void queueWorldHop(int worldId)
+	{
+		if (client.getGameState() == GameState.LOGGED_IN)
+		{
+			hopTarget = worldId;
+			clientThread.invokeLater(() -> logHighlightedToChat("Attempting to quick-hop to world ", String.valueOf(hopTarget)));
+		}
+	}
+
+	private void performHop()
+	{
+		if (++hopAttempts >= 5)
+		{
+			logHighlightedToChat("Unable to quick-hop to world ", String.valueOf(hopTarget));
+			hopTarget = -1;
+			hopAttempts = 0;
+			return;
+		}
+
+		if (client.getWidget(WidgetInfo.WORLD_SWITCHER_LIST) == null)
+		{
+			client.openWorldHopper();
+			return;
+		}
+
+		World[] worldList = client.getWorldList();
+
+		if (worldList == null)
+		{
+			return;
+		}
+
+		for (World world : worldList)
+		{
+			if (world.getId() == hopTarget)
+			{
+				client.hopToWorld(world);
+				break;
+			}
+		}
+
+		hopTarget = -1;
+		hopAttempts = 0;
+	}
+
+	//Credit to https://github.com/pwatts6060/star-info/. Simplified to fit our needs.
+	private void countMiners()
+	{
+		miners = 0;
+		Star star = Star.getStar();
+
+		if (!whitinPlayerDistance())
+		{
+			miners = -1;
+			return;
+		}
+
+		WorldArea areaH = new WorldArea(star.location.dx(-1), 4, 2);
+		WorldArea areaV = new WorldArea(star.location.dy(-1), 2, 4);
+
+		for (Player p : client.getPlayers())
+		{
+			if (!p.getWorldLocation().isInArea2D(areaH, areaV))
+			{
+				continue;
+			}
+
+			miners++;
+		}
+	}
+
+	private boolean whitinPlayerDistance()
+	{
+		return client.getLocalPlayer().getWorldLocation().distanceTo(new WorldArea(Star.getStar().location, 2, 2)) <= PLAYER_RENDER_DISTANCE;
+	}
+
+	private void createCallButton()
+	{
+		if (callButton != null || parent == null || !starConfig.callHorn())
+		{
+			return;
+		}
+
+		callButton = parent.createChild(WidgetType.GRAPHIC);
+		callButton.setSpriteId(SpriteID.BARBARIAN_ASSAULT_HORN_FOR_ATTACKER_ICON);
+		callButton.setOriginalWidth(20);
+		callButton.setOriginalHeight(23);
+		setCallButtonLocation();
+		callButton.setAction(4, "Call star");
+		callButton.setAction(5, "Call dead");
+		callButton.setAction(6, "Call private");
+		callButton.setHasListener(true);
+		callButton.setNoClickThrough(true);
+		callButton.setOnOpListener((JavaScriptCallback) this::callButtonClicked);
+		callButton.revalidate();
+	}
+
+	private void callButtonClicked(ScriptEvent event)
+	{
+		switch (event.getOp())
+		{
+			case CALL_STAR:
+			{
+				prepareCall(true);
+				break;
+			}
+			case CALL_DEAD:
+			{
+				attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, "dead");
+				break;
+			}
+			case CALL_PRIVATE:
+			{
+				attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, "pdead");
+				break;
+			}
+		}
+	}
+
+	private void removeCallButton()
+	{
+		if (parent == null || callButton == null)
+		{
+			return;
+		}
+
+		Widget[] children = parent.getChildren();
+		if (children == null || children.length <= callButton.getIndex() || !children[callButton.getIndex()].equals(callButton))
+		{
+			return;
+		}
+
+		children[callButton.getIndex()] = null;
+		callButton = null;
+		parent = null;
+	}
+
+	private void prepareCall(boolean manual)
+	{
+		if (Star.getStar() == null)
+		{
+			if (manual)
+			{
+				logToChat("Unable to find star.");
+			}
+
+			return;
+		}
+
+		if (lastCalledStar != null
+			&& lastCalledStar.world == Star.getStar().world
+			&& lastCalledStar.tier == Star.getStar().tier
+			&& lastCalledStar.location.equals(Star.getStar().location)
+		)
+		{
+			if (manual)
+			{
+				logToChat("This star has already been called.");
+			}
+
+			return;
+		}
+
+		//Won't automatically call star again if tier decreased and the updateStar option disabled
+		if (lastCalledStar != null
+			&& lastCalledStar.world == Star.getStar().world
+			&& lastCalledStar.location.equals(Star.getStar().location)
+			&& lastCalledStar.tier > Star.getStar().tier
+			&& !starConfig.updateStar() && !manual
+		)
+		{
+			return;
+		}
+
+		String location = Star.getLocationName(Star.getStar().location);
+		if (location.equals("unknown"))
+		{
+			logToChat("Star location is unknown, manual call required.");
+			return;
+		}
+
+		attemptCall(client.getLocalPlayer().getName(), client.getWorld(), Star.getStar().tier, location);
+	}
+
+	private void attemptCall(String username, int world, int tier, String location)
+	{
+		try
+		{
+			sender.sendCall(username, world, tier, location, miners, new Callback()
+			{
+				@Override
+				public void onFailure(Call call, IOException e)
+				{
+					clientThread.invokeLater(() -> {
+						logToChat("Unable to post call to " + starConfig.getEndpoint() + ".");
+					});
+
+					call.cancel();
+				}
+
+				@Override
+				public void onResponse(Call call, Response res) throws IOException
+				{
+					if (res.isSuccessful())
+					{
+						if (tier > 0)
+						{
+							lastCalledStar = Star.getStar();
+						}
+
+						clientThread.invokeLater(() -> logHighlightedToChat(
+							"Successfully posted call: ",
+							"W" + world + " T" + tier + " " + location + ((miners == -1 || tier == 0) ? "" : (" " + miners + " Miners"))
+						));
+					}
+					else
+					{
+						clientThread.invokeLater(() -> logHighlightedToChat(
+							"Issue posting call to " + starConfig.getEndpoint() + ": ",
+							res.message()
+						));
+					}
+
+					res.close();
+				}
+			});
+		}
+		catch (IllegalArgumentException iae)
+		{
+			clientThread.invokeLater(() -> {
+				logHighlightedToChat("Issue posting call to " + starConfig.getEndpoint() + ": ", "Invalid endpoint");
+			});
+		}
+	}
+
+	private void logHighlightedToChat(String normal, String highlight)
+	{
+		if (starConfig.chatMessages())
+		{
+			String chatMessage = new ChatMessageBuilder()
+				.append(ChatColorType.NORMAL)
+				.append(normal)
+				.append(ChatColorType.HIGHLIGHT)
+				.append(highlight)
+				.build();
+
+			chatMessageManager.queue(
+				QueuedMessage.builder()
+					.type(ChatMessageType.CONSOLE)
+					.runeLiteFormattedMessage(chatMessage)
+					.build()
+			);
+		}
+	}
+
+	private void logToChat(String message)
+	{
+		if (starConfig.chatMessages())
+		{
+			client.addChatMessage(ChatMessageType.CONSOLE, "", message, "");
+		}
+	}
+
+	private void setCallButtonLocation()
+	{
+		if (client.isResized())
+		{
+			callButton.setOriginalX(BUTTON_RESIZEABLE_LOCATION.x);
+			callButton.setOriginalY(BUTTON_RESIZEABLE_LOCATION.y);
+		}
+		else
+		{
+			callButton.setOriginalX(BUTTON_FIXED_LOCATION.x);
+			callButton.setOriginalY(BUTTON_FIXED_LOCATION.y);
+		}
+	}
 }

--- a/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
@@ -394,7 +394,7 @@ public class StarCallingAssistPlugin extends Plugin
         }
 
         Widget[] children = parent.getChildren();
-        if (children.length <= callButton.getIndex() || !children[callButton.getIndex()].equals(callButton)) {
+        if (children == null || children.length <= callButton.getIndex() || !children[callButton.getIndex()].equals(callButton)) {
             return;
         }
 

--- a/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
+++ b/src/main/java/com/starcallingassist/StarCallingAssistPlugin.java
@@ -3,26 +3,11 @@ package com.starcallingassist;
 import com.google.inject.Provides;
 import com.starcallingassist.sidepanel.SidePanel;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ChatMessageType;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.Player;
-import net.runelite.api.ScriptEvent;
-import net.runelite.api.SpriteID;
-import net.runelite.api.World;
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.GameObjectDespawned;
-import net.runelite.api.events.GameObjectSpawned;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GameTick;
-import net.runelite.api.events.ResizeableChanged;
-import net.runelite.api.events.WidgetLoaded;
-import net.runelite.api.widgets.JavaScriptCallback;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
-import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.api.widgets.WidgetType;
+import net.runelite.api.events.*;
+import net.runelite.api.widgets.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -38,21 +23,20 @@ import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
-
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Response;
 
 import javax.inject.Inject;
 import javax.swing.*;
-import java.awt.*;
+import java.awt.Point;
 import java.io.IOException;
 import java.time.temporal.ChronoUnit;
 
 @PluginDescriptor(
-	name = "Star Miners",
-	description = "Displays a list of active stars and crowdsources data about stars you find and mine",
-	tags = {"star","shooting","shootingstar","meteor","crowdsource","crowdsourcing"}
+    name = "Star Miners",
+    description = "Displays a list of active stars and crowdsources data about stars you find and mine",
+    tags = {"star", "shooting", "shootingstar", "meteor", "crowdsource", "crowdsourcing"}
 )
 @Slf4j
 public class StarCallingAssistPlugin extends Plugin
@@ -71,438 +55,469 @@ public class StarCallingAssistPlugin extends Plugin
 
     private WorldPoint confirmDeadLocation = null;
 
-    @Inject private StarCallingAssistConfig starConfig;
-    @Inject private ChatMessageManager chatMessageManager;
-    @Inject private WorldService worldService;
-    @Inject private Client client;
-    @Inject private ClientThread clientThread;
-    @Inject private ClientToolbar clientToolbar;
-    @Inject private CallSender sender;
+    @Inject
+    private StarCallingAssistConfig starConfig;
+    @Inject
+    private ChatMessageManager chatMessageManager;
+    @Inject
+    private WorldService worldService;
+    @Inject
+    private Client client;
+    @Inject
+    private ClientThread clientThread;
+    @Inject
+    private ClientToolbar clientToolbar;
+    @Inject
+    private CallSender sender;
 
     private SidePanel sidePanel;
 
     private NavigationButton navButton;
 
-    @Provides StarCallingAssistConfig provideConfig(ConfigManager configManager) {
-	return configManager.getConfig(StarCallingAssistConfig.class);
+    @Provides
+    StarCallingAssistConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(StarCallingAssistConfig.class);
     }
 
-    @Override protected void startUp() throws Exception
+    @Override
+    protected void startUp() throws Exception
     {
-	lastCalledStar = null;
-	parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-	clientThread.invokeLater(this::createCallButton);
+        lastCalledStar = null;
+        parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+        clientThread.invokeLater(this::createCallButton);
 
-	sidePanel = injector.getInstance(SidePanel.class);
-	sidePanel.init();
+        sidePanel = injector.getInstance(SidePanel.class);
+        sidePanel.init();
 
-	navButton = NavigationButton.builder()
-		.tooltip("Star Miners")
-		.icon(ImageUtil.loadImageResource(getClass(), "/sminers.png"))
-		.panel(sidePanel)
-		.build();
-	clientToolbar.addNavigation(navButton);
-	navButton.setOnClick(this::fetchStarData);
+        navButton = NavigationButton.builder()
+                                    .tooltip("Star Miners")
+                                    .icon(ImageUtil.loadImageResource(getClass(), "/sminers.png"))
+                                    .panel(sidePanel)
+                                    .build();
+        clientToolbar.addNavigation(navButton);
+        navButton.setOnClick(this::fetchStarData);
     }
 
-    @Override protected void shutDown() throws Exception
+    @Override
+    protected void shutDown() throws Exception
     {
-	Star.removeStar();
-	lastCalledStar = null;
-	removeCallButton();
-	clientToolbar.removeNavigation(navButton);
+        Star.removeStar();
+        lastCalledStar = null;
+        removeCallButton();
+        clientToolbar.removeNavigation(navButton);
     }
 
-    @Subscribe public void onGameObjectSpawned(GameObjectSpawned event)
+    @Subscribe
+    public void onGameObjectSpawned(GameObjectSpawned event)
     {
-	int tier = Star.getTier(event.getGameObject().getId());
-	if (tier != -1) {
-	    Star.setStar(event.getGameObject(), tier, client.getWorld());
-	    if (starConfig.autoCall())
-	    {
-		if(whitinPlayerDistance())
-		{
-		    countMiners();
-		    prepareCall(false);
-		}
-		else
-		{
-		    miners = -1;
-		    prepareCall(false);
-		}
-	    }
-	}
+        int tier = Star.getTier(event.getGameObject().getId());
+        if (tier != -1) {
+            Star.setStar(event.getGameObject(), tier, client.getWorld());
+
+            if (starConfig.autoCall()) {
+                if (whitinPlayerDistance()) {
+                    countMiners();
+                    prepareCall(false);
+                } else {
+                    miners = -1;
+                    prepareCall(false);
+                }
+            }
+        }
     }
 
-    @Subscribe public void onGameObjectDespawned(GameObjectDespawned event)
+    @Subscribe
+    public void onGameObjectDespawned(GameObjectDespawned event)
     {
-	if (Star.getTier(event.getGameObject().getId()) != -1)
-	{
-	    //Causes a check for whether the star fully depleted in the next GameTick event
-	    if(starConfig.autoCall())
-		confirmDeadLocation = event.getGameObject().getWorldLocation();
+        if (Star.getTier(event.getGameObject().getId()) != -1) {
+            //Causes a check for whether the star fully depleted in the next GameTick event
+            if (starConfig.autoCall()) {
+                confirmDeadLocation = event.getGameObject().getWorldLocation();
+            }
 
-	    Star.removeStar();
-	}
+            Star.removeStar();
+        }
     }
 
-    @Subscribe public void onGameStateChanged(GameStateChanged state)
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged state)
     {
-	if (state.getGameState() == GameState.HOPPING || state.getGameState() == GameState.LOGGING_IN) {
-	    Star.removeStar();
-	    removeCallButton();
-	}
-	if(state.getGameState() == GameState.LOGGED_IN)
-	{
-	    SwingUtilities.invokeLater(() -> sidePanel.rebuildTableRows());
-	    fetchStarData();
-	}
+        if (state.getGameState() == GameState.HOPPING || state.getGameState() == GameState.LOGGING_IN) {
+            Star.removeStar();
+            removeCallButton();
+        }
+
+        if (state.getGameState() == GameState.LOGGED_IN) {
+            SwingUtilities.invokeLater(() -> sidePanel.rebuildTableRows());
+            fetchStarData();
+        }
     }
 
-    @Subscribe public void onGameTick(GameTick tick)
+    @Subscribe
+    public void onGameTick(GameTick tick)
     {
-	if(hopTarget != -1)
-	    performHop();
+        if (hopTarget != -1) {
+            performHop();
+        }
 
-	if(confirmDeadLocation != null)
-	{
-	    if(Star.getStar() == null)
-		if (client.getLocalPlayer().getWorldLocation().distanceTo(confirmDeadLocation) <= 32)
-		    attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, Star.getLocationName(confirmDeadLocation));
+        if (confirmDeadLocation != null) {
+            if (Star.getStar() == null) {
+                if (client.getLocalPlayer().getWorldLocation().distanceTo(confirmDeadLocation) <= 32) {
+                    attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, Star.getLocationName(confirmDeadLocation));
+                }
+            }
 
-	    confirmDeadLocation = null;
-	}
+            confirmDeadLocation = null;
+        }
 
-	if (Star.getStar() != null)
-	{
-	    if (client.getLocalPlayer().getWorldLocation().distanceTo(Star.getStar().location) > 32)
-		Star.removeStar();
+        if (Star.getStar() != null) {
+            if (client.getLocalPlayer().getWorldLocation().distanceTo(Star.getStar().location) > 32) {
+                Star.removeStar();
+            }
 
-	    if(Star.getStar() != null)
-		countMiners();
-	}
+            if (Star.getStar() != null) {
+                countMiners();
+            }
+        }
     }
 
     @Subscribe
     public void onConfigChanged(ConfigChanged event)
     {
-	if (!event.getGroup().equals("starcallingassistplugin"))
-	    return;
+        if (!event.getGroup().equals("starcallingassistplugin")) {
+            return;
+        }
 
-	if (event.getKey().equals("autoCall"))
-	{
-	    if (starConfig.autoCall())
-		clientThread.invokeLater(() -> {prepareCall(false);});
-	    return;
-	}
-	else if (event.getKey().equals("updateStar"))
-	{
-	    if (starConfig.autoCall() && starConfig.updateStar())
-		clientThread.invokeLater(() -> {prepareCall(false);});
-	    return;
-	}
-	else if (event.getKey().equals("callHorn"))
-	{
-	    removeCallButton();
-	    parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-	    clientThread.invokeLater(this::createCallButton);
-	    return;
-	}
-	else if (event.equals("endpoint"))
-	{
-	    fetchStarData();
-	    return;
-	}
-	else if (event.getKey().equals("authorization"))
-	{
-	    sidePanel.updateInfoPanel();
-	    return;
-	}
-	else if (event.getKey().equals("estimateTier"))
-	{
-	    sidePanel.rebuildTableRows();
-	    return;
-	}
+        if (event.getKey().equals("autoCall")) {
+            if (starConfig.autoCall()) {
+                clientThread.invokeLater(() -> prepareCall(false));
+            }
 
-	sidePanel.updateTableRows();
+            return;
+        }
+
+        if (event.getKey().equals("updateStar")) {
+            if (starConfig.autoCall() && starConfig.updateStar()) {
+                clientThread.invokeLater(() -> prepareCall(false));
+            }
+
+            return;
+        }
+
+        if (event.getKey().equals("callHorn")) {
+            removeCallButton();
+            parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+            clientThread.invokeLater(this::createCallButton);
+            return;
+        }
+
+        if (event.equals("endpoint")) {
+            fetchStarData();
+            return;
+        }
+
+        if (event.getKey().equals("authorization")) {
+            sidePanel.updateInfoPanel();
+            return;
+        }
+
+        if (event.getKey().equals("estimateTier")) {
+            sidePanel.rebuildTableRows();
+            return;
+        }
+
+        sidePanel.updateTableRows();
     }
 
     @Subscribe
     public void onWidgetLoaded(WidgetLoaded event)
     {
-	if(event.getGroupId() == WidgetID.MINIMAP_GROUP_ID && (callButton == null || parent == null))
-	{
-	    removeCallButton();
-	    parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-	    createCallButton();
-	}
+        if (event.getGroupId() == WidgetID.MINIMAP_GROUP_ID && (callButton == null || parent == null)) {
+            removeCallButton();
+            parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+            createCallButton();
+        }
     }
 
     @Subscribe
     public void onResizeableChanged(ResizeableChanged event)
     {
-	removeCallButton();
-	parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
-	createCallButton();
+        removeCallButton();
+        parent = client.getWidget(WidgetInfo.MINIMAP_ORBS);
+        createCallButton();
     }
 
     @Schedule(
-	    period = 30,
-	    unit = ChronoUnit.SECONDS
+        period = 30,
+        unit = ChronoUnit.SECONDS
     )
     public void fetchStarData()
     {
-	if(navButton.isSelected())
-	    sidePanel.fetchStarData();
+        if (navButton.isSelected()) {
+            sidePanel.fetchStarData();
+        }
     }
 
     @Schedule(
-	    period = 10,
-	    unit = ChronoUnit.MINUTES
+        period = 10,
+        unit = ChronoUnit.MINUTES
     )
     public void fetchWorldData()
     {
-	sidePanel.fetchWorldData();
+        sidePanel.fetchWorldData();
     }
 
     public Client getClient()
     {
-	return client;
+        return client;
     }
 
     public StarCallingAssistConfig getConfig()
     {
-	return starConfig;
+        return starConfig;
     }
 
     public void queueWorldHop(int worldId)
     {
-	if(client.getGameState() == GameState.LOGGED_IN)
-	{
-	    hopTarget = worldId;
-	    clientThread.invokeLater(() -> logHighlightedToChat("Attempting to quick-hop to world ", hopTarget + ""));
-	}
+        if (client.getGameState() == GameState.LOGGED_IN) {
+            hopTarget = worldId;
+            clientThread.invokeLater(() -> logHighlightedToChat("Attempting to quick-hop to world ", String.valueOf(hopTarget)));
+        }
     }
 
     private void performHop()
     {
-	if(++hopAttempts >= 5)
-	{
-	    logHighlightedToChat("Unable to quick-hop to world ", hopTarget + "");
-	    hopTarget = -1;
-	    hopAttempts = 0;
-	    return;
-	}
+        if (++hopAttempts >= 5) {
+            logHighlightedToChat("Unable to quick-hop to world ", String.valueOf(hopTarget));
+            hopTarget = -1;
+            hopAttempts = 0;
+            return;
+        }
 
-	if (client.getWidget(WidgetInfo.WORLD_SWITCHER_LIST) == null)
-	{
-	    client.openWorldHopper();
-	    return;
-	}
+        if (client.getWidget(WidgetInfo.WORLD_SWITCHER_LIST) == null) {
+            client.openWorldHopper();
+            return;
+        }
 
-	World[] worldList = client.getWorldList();
+        World[] worldList = client.getWorldList();
 
-	if(worldList == null)
-	    return;
+        if (worldList == null) {
+            return;
+        }
 
-	for (World world : worldList)
-	{
-	    if (world.getId() == hopTarget)
-	    {
-		client.hopToWorld(world);
-		break;
-	    }
-	}
+        for (World world : worldList) {
+            if (world.getId() == hopTarget) {
+                client.hopToWorld(world);
+                break;
+            }
+        }
 
-	hopTarget = -1;
-	hopAttempts = 0;
+        hopTarget = -1;
+        hopAttempts = 0;
     }
 
     //Credit to https://github.com/pwatts6060/star-info/. Simplified to fit our needs.
     private void countMiners()
     {
-	miners = 0;
-	Star star = Star.getStar();
+        miners = 0;
+        Star star = Star.getStar();
 
-	if (!whitinPlayerDistance())
-	{
-	    miners = -1;
-	    return;
-	}
+        if (!whitinPlayerDistance()) {
+            miners = -1;
+            return;
+        }
 
-	WorldArea areaH = new WorldArea(star.location.dx(-1), 4, 2);
-	WorldArea areaV = new WorldArea(star.location.dy(-1), 2, 4);
+        WorldArea areaH = new WorldArea(star.location.dx(-1), 4, 2);
+        WorldArea areaV = new WorldArea(star.location.dy(-1), 2, 4);
 
-	for (Player p : client.getPlayers())
-	{
-	    if (!p.getWorldLocation().isInArea2D(areaH, areaV))
-		continue;
-	    miners++;
-	}
+        for (Player p : client.getPlayers()) {
+            if (!p.getWorldLocation().isInArea2D(areaH, areaV)) {
+                continue;
+            }
+
+            miners++;
+        }
     }
 
     private boolean whitinPlayerDistance()
     {
-	return client.getLocalPlayer().getWorldLocation().distanceTo(new WorldArea(Star.getStar().location, 2, 2)) <= PLAYER_RENDER_DISTANCE;
+        return client.getLocalPlayer().getWorldLocation().distanceTo(new WorldArea(Star.getStar().location, 2, 2)) <= PLAYER_RENDER_DISTANCE;
     }
 
     private void createCallButton()
     {
-	if (callButton != null || parent == null || !starConfig.callHorn())
-	    return;
-	callButton = parent.createChild(WidgetType.GRAPHIC);
-	callButton.setSpriteId(SpriteID.BARBARIAN_ASSAULT_HORN_FOR_ATTACKER_ICON);
-	callButton.setOriginalWidth(20);
-	callButton.setOriginalHeight(23);
-	setCallButtonLocation();
-	callButton.setAction(4, "Call star");
-	callButton.setAction(5, "Call dead");
-	callButton.setAction(6, "Call private");
-	callButton.setHasListener(true);
-	callButton.setNoClickThrough(true);
-	callButton.setOnOpListener((JavaScriptCallback) this::callButtonClicked);
-	callButton.revalidate();
+        if (callButton != null || parent == null || !starConfig.callHorn()) {
+            return;
+        }
+
+        callButton = parent.createChild(WidgetType.GRAPHIC);
+        callButton.setSpriteId(SpriteID.BARBARIAN_ASSAULT_HORN_FOR_ATTACKER_ICON);
+        callButton.setOriginalWidth(20);
+        callButton.setOriginalHeight(23);
+        setCallButtonLocation();
+        callButton.setAction(4, "Call star");
+        callButton.setAction(5, "Call dead");
+        callButton.setAction(6, "Call private");
+        callButton.setHasListener(true);
+        callButton.setNoClickThrough(true);
+        callButton.setOnOpListener((JavaScriptCallback) this::callButtonClicked);
+        callButton.revalidate();
     }
 
     private void callButtonClicked(ScriptEvent event)
     {
-	switch (event.getOp())
-	{
-	    case CALL_STAR:
-	    {
-		prepareCall(true);
-		break;
-	    }
-	    case CALL_DEAD:
-	    {
-		attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0 , "dead");
-		break;
-	    }
-	    case CALL_PRIVATE:
-	    {
-		attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0 , "pdead");
-		break;
-	    }
-	}
+        switch (event.getOp()) {
+            case CALL_STAR: {
+                prepareCall(true);
+                break;
+            }
+            case CALL_DEAD: {
+                attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, "dead");
+                break;
+            }
+            case CALL_PRIVATE: {
+                attemptCall(client.getLocalPlayer().getName(), client.getWorld(), 0, "pdead");
+                break;
+            }
+        }
     }
 
     private void removeCallButton()
     {
-	if (parent == null || callButton == null)
-	    return;
-	Widget[] children = parent.getChildren();
-	if (children.length <= callButton.getIndex() || !children[callButton.getIndex()].equals(callButton))
-	    return;
-	children[callButton.getIndex()] = null;
-	callButton = null;
-	parent = null;
+        if (parent == null || callButton == null) {
+            return;
+        }
+
+        Widget[] children = parent.getChildren();
+        if (children.length <= callButton.getIndex() || !children[callButton.getIndex()].equals(callButton)) {
+            return;
+        }
+
+        children[callButton.getIndex()] = null;
+        callButton = null;
+        parent = null;
     }
 
     private void prepareCall(boolean manual)
     {
-	if (Star.getStar() == null)
-	{
-	    if(manual)
-		logToChat("Unable to find star.");
-	    return;
-	}
-	else if (lastCalledStar != null
-		 && lastCalledStar.world == Star.getStar().world
-		 && lastCalledStar.tier == Star.getStar().tier
-		 && lastCalledStar.location.equals(Star.getStar().location))
-	{
-	    if (manual)
-		logToChat("This star has already been called.");
-	    return;
-	}
-	//Won't automatically call star again if tier decreased and the updateStar option disabled
-	else if(lastCalledStar != null  && lastCalledStar.world == Star.getStar().world
-		&& lastCalledStar.location.equals(Star.getStar().location)
-		&& lastCalledStar.tier > Star.getStar().tier
-		&& !starConfig.updateStar() && !manual)
-	{
-	    return;
-	}
-	String location = Star.getLocationName(Star.getStar().location);
-	if (location.equals("unknown"))
-	{
-	    logToChat("Star location is unknown, manual call required.");
-	    return;
-	}
-	attemptCall(client.getLocalPlayer().getName(), client.getWorld(), Star.getStar().tier, location);
+        if (Star.getStar() == null) {
+            if (manual) {
+                logToChat("Unable to find star.");
+            }
+
+            return;
+        }
+
+        if (lastCalledStar != null
+            && lastCalledStar.world == Star.getStar().world
+            && lastCalledStar.tier == Star.getStar().tier
+            && lastCalledStar.location.equals(Star.getStar().location)
+        ) {
+            if (manual) {
+                logToChat("This star has already been called.");
+            }
+
+            return;
+        }
+
+        //Won't automatically call star again if tier decreased and the updateStar option disabled
+        if (lastCalledStar != null
+            && lastCalledStar.world == Star.getStar().world
+            && lastCalledStar.location.equals(Star.getStar().location)
+            && lastCalledStar.tier > Star.getStar().tier
+            && !starConfig.updateStar() && !manual
+        ) {
+            return;
+        }
+
+        String location = Star.getLocationName(Star.getStar().location);
+        if (location.equals("unknown")) {
+            logToChat("Star location is unknown, manual call required.");
+            return;
+        }
+
+        attemptCall(client.getLocalPlayer().getName(), client.getWorld(), Star.getStar().tier, location);
     }
 
     private void attemptCall(String username, int world, int tier, String location)
     {
-	try
-	{
-	    sender.sendCall(username, world, tier, location, miners, new Callback()
-	    {
-		@Override
-		public void onFailure(Call call, IOException e)
-		{
-		    clientThread.invokeLater(() -> {logToChat("Unable to post call to " + starConfig.getEndpoint() + ".");});
-		    call.cancel();
-		}
-		@Override
-		public void onResponse(Call call, Response res) throws IOException
-		{
-		    if (res.isSuccessful()) {
-			if (tier > 0)
-			    lastCalledStar = Star.getStar();
-			clientThread.invokeLater(() -> {
-			    logHighlightedToChat(
-				    "Successfully posted call: ",
-				    "W" + world + " T" + tier + " " + location + ((miners == -1 || tier == 0) ? "" : (" " + miners + " Miners"))
-			    );
-			});
-		    } else {
-			clientThread.invokeLater(() -> {logHighlightedToChat("Issue posting call to " + starConfig.getEndpoint() + ": ", res.message());});
-		    }
-		    res.close();
-		}
-	    });
-	}
-	catch (IllegalArgumentException iae)
-	{
-	    clientThread.invokeLater(() -> {logHighlightedToChat("Issue posting call to " + starConfig.getEndpoint() + ": ", "Invalid endpoint");});
-	}
+        try {
+            sender.sendCall(username, world, tier, location, miners, new Callback()
+            {
+                @Override
+                public void onFailure(Call call, IOException e)
+                {
+                    clientThread.invokeLater(() -> {
+                        logToChat("Unable to post call to " + starConfig.getEndpoint() + ".");
+                    });
+
+                    call.cancel();
+                }
+
+                @Override
+                public void onResponse(Call call, Response res) throws IOException
+                {
+                    if (res.isSuccessful()) {
+                        if (tier > 0) {
+                            lastCalledStar = Star.getStar();
+                        }
+
+                        clientThread.invokeLater(() -> logHighlightedToChat(
+                            "Successfully posted call: ",
+                            "W" + world + " T" + tier + " " + location + ((miners == -1 || tier == 0) ? "" : (" " + miners + " Miners"))
+                        ));
+                    } else {
+                        clientThread.invokeLater(() -> logHighlightedToChat(
+                            "Issue posting call to " + starConfig.getEndpoint() + ": ",
+                            res.message()
+                        ));
+                    }
+
+                    res.close();
+                }
+            });
+        } catch (IllegalArgumentException iae) {
+            clientThread.invokeLater(() -> {
+                logHighlightedToChat("Issue posting call to " + starConfig.getEndpoint() + ": ", "Invalid endpoint");
+            });
+        }
     }
 
     private void logHighlightedToChat(String normal, String highlight)
     {
-	if(starConfig.chatMessages())
-	{
-	    String chatMessage = new ChatMessageBuilder()
-		    .append(ChatColorType.NORMAL)
-		    .append(normal)
-		    .append(ChatColorType.HIGHLIGHT)
-		    .append(highlight)
-		    .build();
-	    chatMessageManager.queue(QueuedMessage.builder()
-					     .type(ChatMessageType.CONSOLE)
-					     .runeLiteFormattedMessage(chatMessage)
-					     .build());
-	}
+        if (starConfig.chatMessages()) {
+            String chatMessage = new ChatMessageBuilder()
+                .append(ChatColorType.NORMAL)
+                .append(normal)
+                .append(ChatColorType.HIGHLIGHT)
+                .append(highlight)
+                .build();
+
+            chatMessageManager.queue(
+                QueuedMessage.builder()
+                             .type(ChatMessageType.CONSOLE)
+                             .runeLiteFormattedMessage(chatMessage)
+                             .build()
+            );
+        }
     }
 
     private void logToChat(String message)
     {
-	if (starConfig.chatMessages())
-	    client.addChatMessage(ChatMessageType.CONSOLE, "", message, "");
+        if (starConfig.chatMessages()) {
+            client.addChatMessage(ChatMessageType.CONSOLE, "", message, "");
+        }
     }
 
     private void setCallButtonLocation()
     {
-	if (client.isResized())
-	{
-	    callButton.setOriginalX(BUTTON_RESIZEABLE_LOCATION.x);
-	    callButton.setOriginalY(BUTTON_RESIZEABLE_LOCATION.y);
-	}
-	else
-	{
-	    callButton.setOriginalX(BUTTON_FIXED_LOCATION.x);
-	    callButton.setOriginalY(BUTTON_FIXED_LOCATION.y);
-	}
+        if (client.isResized()) {
+            callButton.setOriginalX(BUTTON_RESIZEABLE_LOCATION.x);
+            callButton.setOriginalY(BUTTON_RESIZEABLE_LOCATION.y);
+        } else {
+            callButton.setOriginalX(BUTTON_FIXED_LOCATION.x);
+            callButton.setOriginalY(BUTTON_FIXED_LOCATION.y);
+        }
     }
 }

--- a/src/main/java/com/starcallingassist/sidepanel/InfoPanel.java
+++ b/src/main/java/com/starcallingassist/sidepanel/InfoPanel.java
@@ -14,112 +14,116 @@ import java.net.URI;
 @Slf4j
 public class InfoPanel extends JPanel
 {
-
     private final StarCallingAssistPlugin plugin;
     private String errorMessage = "";
 
     public InfoPanel(StarCallingAssistPlugin plugin)
     {
-	this.plugin = plugin;
+        this.plugin = plugin;
 
-	setLayout(new BorderLayout());
-	setBackground(ColorScheme.SCROLL_TRACK_COLOR);
+        setLayout(new BorderLayout());
+        setBackground(ColorScheme.SCROLL_TRACK_COLOR);
 
-	build();
+        build();
     }
 
     public void rebuild()
     {
-	removeAll();
+        removeAll();
 
-	build();
+        build();
 
-	revalidate();
-	repaint();
+        revalidate();
+        repaint();
     }
 
     public void setErrorMessage(String errorMessage)
     {
-	if(errorMessage.equals(this.errorMessage))
-	    return;
-	this.errorMessage = errorMessage;
-	rebuild();
+        if (errorMessage.equals(this.errorMessage)) {
+            return;
+        }
+
+        this.errorMessage = errorMessage;
+        rebuild();
     }
 
     private void build()
     {
-	JPanel top = new JPanel(new BorderLayout());
-	JPanel bottom = new JPanel(new BorderLayout());
+        JPanel top = new JPanel(new BorderLayout());
+        JPanel bottom = new JPanel(new BorderLayout());
 
-	JPanel discordAdvert = new JPanel(new BorderLayout());
+        JPanel discordAdvert = new JPanel(new BorderLayout());
 
-	JLabel discordLink = createClickableLink("https://discord.gg/starminers", "Join the Star Miners discord!");
-	discordLink.setHorizontalAlignment(SwingConstants.CENTER);
+        JLabel discordLink = createClickableLink("https://discord.gg/starminers", "Join the Star Miners discord!");
+        discordLink.setHorizontalAlignment(SwingConstants.CENTER);
 
-	discordAdvert.add(discordLink, BorderLayout.CENTER);
-	discordAdvert.setOpaque(false);
+        discordAdvert.add(discordLink, BorderLayout.CENTER);
+        discordAdvert.setOpaque(false);
 
-	top.add(discordAdvert, BorderLayout.NORTH);
+        top.add(discordAdvert, BorderLayout.NORTH);
 
-	if(plugin.getConfig().getAuthorization().isEmpty())
-	{
-	    JPanel missingKeyInfo = new JPanel(new BorderLayout());
-	    JLabel keyInfo = new JLabel("<html>To see the list of active stars you need to enter your unique key into the " +
-					"<b>Authorization</b> field in the plugin settings. <br><br> You can get your unique key from " +
-					"the starminers discord: <br><br> discord.gg/starminers</html>");
-	    keyInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
-	    missingKeyInfo.add(keyInfo);
+        if (plugin.getConfig().getAuthorization().isEmpty()) {
+            JPanel missingKeyInfo = new JPanel(new BorderLayout());
+            JLabel keyInfo = new JLabel("<html>To see the list of active stars you need to enter your unique key into the " +
+                                        "<b>Authorization</b> field in the plugin settings. <br><br> You can get your unique key from " +
+                                        "the starminers discord: <br><br> discord.gg/starminers</html>");
+            keyInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
+            missingKeyInfo.add(keyInfo);
 
-	    missingKeyInfo.setOpaque(false);
+            missingKeyInfo.setOpaque(false);
 
-	    top.add(missingKeyInfo, BorderLayout.SOUTH);
-	}
+            top.add(missingKeyInfo, BorderLayout.SOUTH);
+        }
 
-	top.setOpaque(false);
-	add(top, BorderLayout.NORTH);
+        top.setOpaque(false);
+        add(top, BorderLayout.NORTH);
 
-	if(!errorMessage.isEmpty())
-	{
-	    JPanel errorPanel = new JPanel(new BorderLayout());
-	    JLabel errorInfo = new JLabel("<html>Error when fetching list of stars: <br><br>" + errorMessage + "</html>");
-	    errorInfo.setForeground(Color.RED);
-	    errorInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
-	    errorPanel.add(errorInfo);
+        if (!errorMessage.isEmpty()) {
+            JPanel errorPanel = new JPanel(new BorderLayout());
+            JLabel errorInfo = new JLabel("<html>Error when fetching list of stars: <br><br>" + errorMessage + "</html>");
+            errorInfo.setForeground(Color.RED);
+            errorInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
+            errorPanel.add(errorInfo);
 
-	    errorPanel.setOpaque(false);
+            errorPanel.setOpaque(false);
 
-	    bottom.add(errorPanel, BorderLayout.NORTH);
+            bottom.add(errorPanel, BorderLayout.NORTH);
 
-	    bottom.setOpaque(false);
-	    add(bottom, BorderLayout.SOUTH);
-	}
+            bottom.setOpaque(false);
+            add(bottom, BorderLayout.SOUTH);
+        }
     }
 
-    private  JLabel createClickableLink(final String url, String text) {
-	JLabel linkLabel = new JLabel("<html><a href=''>" + text + "</a></html>");
-	linkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+    private JLabel createClickableLink(final String url, String text)
+    {
+        JLabel linkLabel = new JLabel("<html><a href=''>" + text + "</a></html>");
+        linkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
 
-	linkLabel.addMouseListener(new MouseAdapter() {
-	    @Override
-	    public void mouseClicked(MouseEvent e) {
-		try {
-		    Desktop.getDesktop().browse(new URI(url));
-		} catch (Exception ex) {
-		    log.error(ex.getMessage());
-		}
-	    }
+        linkLabel.addMouseListener(new MouseAdapter()
+        {
+            @Override
+            public void mouseClicked(MouseEvent e)
+            {
+                try {
+                    Desktop.getDesktop().browse(new URI(url));
+                } catch (Exception ex) {
+                    log.error(ex.getMessage());
+                }
+            }
 
-	    @Override
-	    public void mouseEntered(MouseEvent e) {
-		linkLabel.setText("<html><u><font color='orange'>" + text + "</font></u></html>");
-	    }
+            @Override
+            public void mouseEntered(MouseEvent e)
+            {
+                linkLabel.setText("<html><u><font color='orange'>" + text + "</font></u></html>");
+            }
 
-	    @Override
-	    public void mouseExited(MouseEvent e) {
-		linkLabel.setText("<html><a href=''>" + text + "</a></html>");
-	    }
-	});
+            @Override
+            public void mouseExited(MouseEvent e)
+            {
+                linkLabel.setText("<html><a href=''>" + text + "</a></html>");
+            }
+        });
 
-	return linkLabel;
+        return linkLabel;
     }
 }

--- a/src/main/java/com/starcallingassist/sidepanel/InfoPanel.java
+++ b/src/main/java/com/starcallingassist/sidepanel/InfoPanel.java
@@ -64,9 +64,11 @@ public class InfoPanel extends JPanel
 
         if (plugin.getConfig().getAuthorization().isEmpty()) {
             JPanel missingKeyInfo = new JPanel(new BorderLayout());
-            JLabel keyInfo = new JLabel("<html>To see the list of active stars you need to enter your unique key into the " +
-                                        "<b>Authorization</b> field in the plugin settings. <br><br> You can get your unique key from " +
-                                        "the starminers discord: <br><br> discord.gg/starminers</html>");
+            JLabel keyInfo = new JLabel(
+                "<html>To see the list of active stars you need to enter your unique key into the " +
+                "<b>Authorization</b> field in the plugin settings. <br><br> You can get your unique key from " +
+                "the starminers discord: <br><br> discord.gg/starminers</html>"
+            );
             keyInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
             missingKeyInfo.add(keyInfo);
 

--- a/src/main/java/com/starcallingassist/sidepanel/InfoPanel.java
+++ b/src/main/java/com/starcallingassist/sidepanel/InfoPanel.java
@@ -1,131 +1,141 @@
 package com.starcallingassist.sidepanel;
 
 import com.starcallingassist.StarCallingAssistPlugin;
-import lombok.extern.slf4j.Slf4j;
-import net.runelite.client.ui.ColorScheme;
-
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Desktop;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.net.URI;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.ui.ColorScheme;
 
 @Slf4j
 public class InfoPanel extends JPanel
 {
-    private final StarCallingAssistPlugin plugin;
-    private String errorMessage = "";
+	private final StarCallingAssistPlugin plugin;
+	private String errorMessage = "";
 
-    public InfoPanel(StarCallingAssistPlugin plugin)
-    {
-        this.plugin = plugin;
+	public InfoPanel(StarCallingAssistPlugin plugin)
+	{
+		this.plugin = plugin;
 
-        setLayout(new BorderLayout());
-        setBackground(ColorScheme.SCROLL_TRACK_COLOR);
+		setLayout(new BorderLayout());
+		setBackground(ColorScheme.SCROLL_TRACK_COLOR);
 
-        build();
-    }
+		build();
+	}
 
-    public void rebuild()
-    {
-        removeAll();
+	public void rebuild()
+	{
+		removeAll();
 
-        build();
+		build();
 
-        revalidate();
-        repaint();
-    }
+		revalidate();
+		repaint();
+	}
 
-    public void setErrorMessage(String errorMessage)
-    {
-        if (errorMessage.equals(this.errorMessage)) {
-            return;
-        }
+	public void setErrorMessage(String errorMessage)
+	{
+		if (errorMessage.equals(this.errorMessage))
+		{
+			return;
+		}
 
-        this.errorMessage = errorMessage;
-        rebuild();
-    }
+		this.errorMessage = errorMessage;
+		rebuild();
+	}
 
-    private void build()
-    {
-        JPanel top = new JPanel(new BorderLayout());
-        JPanel bottom = new JPanel(new BorderLayout());
+	private void build()
+	{
+		JPanel top = new JPanel(new BorderLayout());
+		JPanel bottom = new JPanel(new BorderLayout());
 
-        JPanel discordAdvert = new JPanel(new BorderLayout());
+		JPanel discordAdvert = new JPanel(new BorderLayout());
 
-        JLabel discordLink = createClickableLink("https://discord.gg/starminers", "Join the Star Miners discord!");
-        discordLink.setHorizontalAlignment(SwingConstants.CENTER);
+		JLabel discordLink = createClickableLink("https://discord.gg/starminers", "Join the Star Miners discord!");
+		discordLink.setHorizontalAlignment(SwingConstants.CENTER);
 
-        discordAdvert.add(discordLink, BorderLayout.CENTER);
-        discordAdvert.setOpaque(false);
+		discordAdvert.add(discordLink, BorderLayout.CENTER);
+		discordAdvert.setOpaque(false);
 
-        top.add(discordAdvert, BorderLayout.NORTH);
+		top.add(discordAdvert, BorderLayout.NORTH);
 
-        if (plugin.getConfig().getAuthorization().isEmpty()) {
-            JPanel missingKeyInfo = new JPanel(new BorderLayout());
-            JLabel keyInfo = new JLabel(
-                "<html>To see the list of active stars you need to enter your unique key into the " +
-                "<b>Authorization</b> field in the plugin settings. <br><br> You can get your unique key from " +
-                "the starminers discord: <br><br> discord.gg/starminers</html>"
-            );
-            keyInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
-            missingKeyInfo.add(keyInfo);
+		if (plugin.getConfig().getAuthorization().isEmpty())
+		{
+			JPanel missingKeyInfo = new JPanel(new BorderLayout());
+			JLabel keyInfo = new JLabel(
+				"<html>To see the list of active stars you need to enter your unique key into the " +
+					"<b>Authorization</b> field in the plugin settings. <br><br> You can get your unique key from " +
+					"the starminers discord: <br><br> discord.gg/starminers</html>"
+			);
+			keyInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
+			missingKeyInfo.add(keyInfo);
 
-            missingKeyInfo.setOpaque(false);
+			missingKeyInfo.setOpaque(false);
 
-            top.add(missingKeyInfo, BorderLayout.SOUTH);
-        }
+			top.add(missingKeyInfo, BorderLayout.SOUTH);
+		}
 
-        top.setOpaque(false);
-        add(top, BorderLayout.NORTH);
+		top.setOpaque(false);
+		add(top, BorderLayout.NORTH);
 
-        if (!errorMessage.isEmpty()) {
-            JPanel errorPanel = new JPanel(new BorderLayout());
-            JLabel errorInfo = new JLabel("<html>Error when fetching list of stars: <br><br>" + errorMessage + "</html>");
-            errorInfo.setForeground(Color.RED);
-            errorInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
-            errorPanel.add(errorInfo);
+		if (!errorMessage.isEmpty())
+		{
+			JPanel errorPanel = new JPanel(new BorderLayout());
+			JLabel errorInfo = new JLabel("<html>Error when fetching list of stars: <br><br>" + errorMessage + "</html>");
+			errorInfo.setForeground(Color.RED);
+			errorInfo.setBorder(new EmptyBorder(10, 3, 5, 3));
+			errorPanel.add(errorInfo);
 
-            errorPanel.setOpaque(false);
+			errorPanel.setOpaque(false);
 
-            bottom.add(errorPanel, BorderLayout.NORTH);
+			bottom.add(errorPanel, BorderLayout.NORTH);
 
-            bottom.setOpaque(false);
-            add(bottom, BorderLayout.SOUTH);
-        }
-    }
+			bottom.setOpaque(false);
+			add(bottom, BorderLayout.SOUTH);
+		}
+	}
 
-    private JLabel createClickableLink(final String url, String text)
-    {
-        JLabel linkLabel = new JLabel("<html><a href=''>" + text + "</a></html>");
-        linkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+	private JLabel createClickableLink(final String url, String text)
+	{
+		JLabel linkLabel = new JLabel("<html><a href=''>" + text + "</a></html>");
+		linkLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
 
-        linkLabel.addMouseListener(new MouseAdapter()
-        {
-            @Override
-            public void mouseClicked(MouseEvent e)
-            {
-                try {
-                    Desktop.getDesktop().browse(new URI(url));
-                } catch (Exception ex) {
-                    log.error(ex.getMessage());
-                }
-            }
+		linkLabel.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				try
+				{
+					Desktop.getDesktop().browse(new URI(url));
+				}
+				catch (Exception ex)
+				{
+					log.error(ex.getMessage());
+				}
+			}
 
-            @Override
-            public void mouseEntered(MouseEvent e)
-            {
-                linkLabel.setText("<html><u><font color='orange'>" + text + "</font></u></html>");
-            }
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				linkLabel.setText("<html><u><font color='orange'>" + text + "</font></u></html>");
+			}
 
-            @Override
-            public void mouseExited(MouseEvent e)
-            {
-                linkLabel.setText("<html><a href=''>" + text + "</a></html>");
-            }
-        });
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				linkLabel.setText("<html><a href=''>" + text + "</a></html>");
+			}
+		});
 
-        return linkLabel;
-    }
+		return linkLabel;
+	}
 }

--- a/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
+++ b/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
@@ -7,7 +7,10 @@ import com.google.gson.JsonObject;
 import com.starcallingassist.StarCallingAssistPlugin;
 import com.starcallingassist.sidepanel.constants.OrderBy;
 import com.starcallingassist.sidepanel.constants.Region;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
@@ -15,7 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.swing.*;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -30,408 +34,445 @@ import net.runelite.http.api.worlds.WorldResult;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
-import okhttp3.Request.Builder;
 import okhttp3.Request;
+import okhttp3.Request.Builder;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 @Slf4j
 public class SidePanel extends PluginPanel
 {
-    private static final Color ODD_ROW_COLOR = new Color(44, 44, 44);
-
-    public static final int WORLD_COLUMN_WIDTH = 30;
-    public static final int TIER_COLUMN_WIDTH = 20;
-    public static final int DEAD_TIME_COLUMN_WIDTH = 40;
-    public static final int FOUND_BY_COLUMN_WIDTH = 50;
-
-    private static final int FETCH_TIMEOUT = 20 * 1000;
-
-    private long nextFetch = 0;
-
-    private TableHeader worldHeader;
-    private TableHeader tierHeader;
-    private TableHeader locationHeader;
-    private TableHeader deadTimeHeader;
-    private TableHeader foundByHeader;
-
-    private JPanel tableRowContainer;
-    private InfoPanel infoPanel;
-
-    @Inject
-    OkHttpClient okHttpClient;
-    @Inject
-    Gson gson;
-    @Inject
-    WorldService worldService;
-    @Inject
-    StarCallingAssistPlugin plugin;
-    @Inject
-    ConfigManager configManager;
-
-    @Getter
-    private OrderBy orderBy = OrderBy.TIER;
-
-    @Getter
-    @Setter
-    private boolean ascendingOrder = true;
-
-    private final List<TableRow> tableRows = new ArrayList<>();
-    private List<StarData> starData = new ArrayList<>();
-    private List<World> worldList = new ArrayList<>();
-
-    private class HeaderMouseListener extends MouseAdapter
-    {
-        private final OrderBy orderBy;
-        private final SidePanel sidePanel;
-
-        public HeaderMouseListener(OrderBy orderBy, SidePanel sidePanel)
-        {
-            this.orderBy = orderBy;
-            this.sidePanel = sidePanel;
-        }
-
-        @Override
-        public void mousePressed(MouseEvent mouseEvent)
-        {
-            if (SwingUtilities.isRightMouseButton(mouseEvent)) {
-                return;
-            }
-
-            sidePanel.setAscendingOrder(sidePanel.getOrderBy() != orderBy || !sidePanel.isAscendingOrder());
-            sidePanel.setOrderBy(orderBy);
-        }
-    }
-
-    public void init()
-    {
-        setBorder(null);
-        setLayout(new DynamicGridLayout(0, 1));
-
-        infoPanel = new InfoPanel(plugin);
-
-        JPanel headerContainer = buildTableHeader();
-        tableRowContainer = new JPanel();
-        tableRowContainer.setLayout(new GridLayout(0, 1));
-
-        add(infoPanel);
-        add(headerContainer);
-        add(tableRowContainer);
-
-        fetchWorldData();
-        fetchStarData();
-    }
-
-    public void updateInfoPanel()
-    {
-        infoPanel.rebuild();
-    }
-
-    public void updateTableRows()
-    {
-        tableRowContainer.removeAll();
-
-        tableRows.sort((r1, r2) ->
-        {
-            switch (orderBy) {
-                case WORLD:
-                    return ascendingOrder
-                        ? Integer.compare(r2.getData().getWorldId(), r1.getData().getWorldId())
-                        : Integer.compare(r1.getData().getWorldId(), r2.getData().getWorldId());
-                case TIER:
-                    return ascendingOrder
-                        ? Integer.compare(r2.getData().getTier(plugin.getConfig().estimateTier()), r1.getData().getTier(plugin.getConfig().estimateTier()))
-                        : Integer.compare(r1.getData().getTier(plugin.getConfig().estimateTier()), r2.getData().getTier(plugin.getConfig().estimateTier()));
-                case LOCATION:
-                    return ascendingOrder
-                        ? r2.getData().getLocation().compareTo(r1.getData().getLocation())
-                        : r1.getData().getLocation().compareTo(r2.getData().getLocation());
-                case DEAD_TIME:
-                    return ascendingOrder
-                        ? Integer.compare(r2.getData().getDeadTime(), r1.getData().getDeadTime())
-                        : Integer.compare(r1.getData().getDeadTime(), r2.getData().getDeadTime());
-                default:
-                    return 0;
-            }
-        });
-
-        for (TableRow row : tableRows) {
-            row.setRowVisible(shouldBeVisible(row.getData()));
-
-            if (row.isRowVisible()) {
-                tableRowContainer.add(row);
-            }
-        }
-
-        colorRows();
-
-        tableRowContainer.revalidate();
-        tableRowContainer.repaint();
-    }
-
-    public void rebuildTableRows()
-    {
-        tableRows.clear();
-
-        for (StarData data : starData) {
-            tableRows.add(new TableRow(data, plugin));
-        }
-
-        updateTableRows();
-    }
-
-    private boolean shouldBeVisible(StarData data)
-    {
-        if (data.isP2p() && !plugin.getConfig().showMembers()) {
-            return false;
-        }
-
-        if (!data.isP2p() && !plugin.getConfig().showF2P()) {
-            return false;
-        }
-
-        if (data.isPvp() && !plugin.getConfig().showPvp()) {
-            return false;
-        }
-
-        if (data.isHighRisk() && !plugin.getConfig().showHighRisk()) {
-            return false;
-        }
-
-        if (data.getTotalLevelType().ordinal() > plugin.getConfig().totalLevelType().ordinal()) {
-            return false;
-        }
-
-        if (data.getTier(plugin.getConfig().estimateTier()) < plugin.getConfig().minTier() ||
-            data.getTier(plugin.getConfig().estimateTier()) > plugin.getConfig().maxTier()
-        ) {
-            return false;
-        }
-
-        if (data.getDeadTime() < plugin.getConfig().minDeadTime()) {
-            return false;
-        }
-
-        Region[] regions = Region.values();
-
-        if (data.getRegion() >= 0 && data.getRegion() < regions.length) {
-            return Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", regions[data.getRegion()].getKeyName()));
-        }
-
-        return true;
-    }
-
-    private void colorRows()
-    {
-        int i = 0;
-        for (TableRow row : tableRows) {
-            if (!row.isRowVisible()) {
-                continue;
-            }
-
-            row.setBackground(i++ % 2 == 0
-                ? ColorScheme.DARKER_GRAY_COLOR
-                : ODD_ROW_COLOR
-            );
-        }
-    }
-
-    private JPanel buildTableHeader()
-    {
-        JPanel header = new JPanel(new BorderLayout());
-        JPanel leftSide = new JPanel(new BorderLayout());
-        JPanel center = new JPanel(new BorderLayout());
-        JPanel rightSide = new JPanel(new BorderLayout());
-
-        worldHeader = new TableHeader("W", orderBy == OrderBy.WORLD, ascendingOrder);
-        worldHeader.setPreferredSize(new Dimension(WORLD_COLUMN_WIDTH, 0));
-        worldHeader.addMouseListener(new HeaderMouseListener(OrderBy.WORLD, this));
-
-        tierHeader = new TableHeader("T", orderBy == OrderBy.TIER, ascendingOrder);
-        tierHeader.setPreferredSize(new Dimension(TIER_COLUMN_WIDTH, 0));
-        tierHeader.addMouseListener(new HeaderMouseListener(OrderBy.TIER, this));
-
-        locationHeader = new TableHeader("Location", orderBy == OrderBy.LOCATION, ascendingOrder);
-        locationHeader.addMouseListener(new HeaderMouseListener(OrderBy.LOCATION, this));
-
-        deadTimeHeader = new TableHeader("Dead", orderBy == OrderBy.DEAD_TIME, ascendingOrder);
-        deadTimeHeader.setPreferredSize(new Dimension(DEAD_TIME_COLUMN_WIDTH, 0));
-        deadTimeHeader.addMouseListener(new HeaderMouseListener(OrderBy.DEAD_TIME, this));
-
-        foundByHeader = new TableHeader("Found by");
-        foundByHeader.setPreferredSize(new Dimension(FOUND_BY_COLUMN_WIDTH, 0));
-
-        leftSide.add(worldHeader, BorderLayout.WEST);
-        leftSide.add(tierHeader, BorderLayout.CENTER);
-        center.add(locationHeader, BorderLayout.CENTER);
-        rightSide.add(deadTimeHeader, BorderLayout.CENTER);
-        rightSide.add(foundByHeader, BorderLayout.EAST);
-
-        header.add(leftSide, BorderLayout.WEST);
-        header.add(center, BorderLayout.CENTER);
-        header.add(rightSide, BorderLayout.EAST);
-
-        return header;
-    }
-
-    public void setOrderBy(OrderBy order)
-    {
-        worldHeader.highlight(false, ascendingOrder);
-        tierHeader.highlight(false, ascendingOrder);
-        locationHeader.highlight(false, ascendingOrder);
-        deadTimeHeader.highlight(false, ascendingOrder);
-
-        switch (order) {
-            case WORLD:
-                worldHeader.highlight(true, ascendingOrder);
-                break;
-            case TIER:
-                tierHeader.highlight(true, ascendingOrder);
-                break;
-            case LOCATION:
-                locationHeader.highlight(true, ascendingOrder);
-                break;
-            case DEAD_TIME:
-                deadTimeHeader.highlight(true, ascendingOrder);
-                break;
-        }
-        orderBy = order;
-        updateTableRows();
-    }
-
-    public void fetchWorldData()
-    {
-        WorldResult worldResult = worldService.getWorlds();
-        if (worldResult == null) {
-            return;
-        }
-
-        List<World> worlds = worldResult.getWorlds();
-        if (worlds == null || worlds.isEmpty()) {
-            return;
-        }
-
-        worldList = worlds;
-    }
-
-    private World getWorldObject(int worldId)
-    {
-        return worldList.stream()
-                        .filter(world -> world.getId() == worldId)
-                        .findFirst()
-                        .orElse(null);
-    }
-
-    public void fetchStarData()
-    {
-        // Don't fetch if less than 10s since last
-        if (nextFetch > System.currentTimeMillis()) {
-            return;
-        }
-
-        if (plugin.getConfig().getAuthorization().isEmpty()) {
-            SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
-            return;
-        }
-
-        if (plugin.getClient().getGameState() != GameState.LOGGED_IN) {
-            SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("You need to be logged in to update the list!"));
-            return;
-        }
-
-        nextFetch = System.currentTimeMillis() + FETCH_TIMEOUT;
-
-        try {
-            Request request = new Builder()
-                .url(plugin.getConfig().getEndpoint())
-                .addHeader("authorization", plugin.getConfig().getAuthorization())
-                .addHeader("plugin", plugin.getName())
-                .get()
-                .build();
-
-            okHttpClient.newCall(request).enqueue(new Callback()
-            {
-                @Override
-                public void onFailure(Call call, IOException e)
-                {
-                    SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(e.getMessage()));
-                    call.cancel();
-                }
-
-                @Override
-                public void onResponse(Call call, Response res) throws IOException
-                {
-                    if (res.isSuccessful()) {
-                        SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
-                        parseData(res.body());
-                    } else {
-                        SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(res.message()));
-                    }
-
-                    res.close();
-                }
-            });
-        } catch (IllegalArgumentException iae) {
-            SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("Invalid endpoint!"));
-        }
-    }
-
-    private void parseData(@Nullable ResponseBody body)
-    {
-        List<StarData> starData = new ArrayList<>();
-        if (body == null) {
-            return;
-        }
-
-        try {
-            JsonArray jsonArray = gson.fromJson(body.string(), JsonArray.class);
-            if (jsonArray.size() < 1) {
-                return;
-            }
-
-            for (final JsonElement element : jsonArray) {
-                JsonObject obj = element.getAsJsonObject();
-                if (obj.has("world") &&
-                    obj.has("tier") &&
-                    obj.has("calledLocation") &&
-                    obj.has("calledBy") &&
-                    obj.has("calledAt") &&
-                    obj.has("location")
-                ) {
-                    starData.add(
-                        new StarData(
-                            obj.get("world").getAsInt(),
-                            getWorldObject(obj.get("world").getAsInt()),
-                            obj.get("tier").getAsInt(),
-                            obj.get("calledLocation").getAsString(),
-                            obj.get("calledBy").getAsString(),
-                            obj.get("calledAt").getAsLong(),
-                            obj.get("location").getAsInt()
-                        )
-                    );
-                }
-            }
-        } catch (Exception e) {
-            log.error("Error parsing response! " + e.getMessage());
-        }
-
-        if (!starData.isEmpty()) {
-            this.starData = starData;
-            SwingUtilities.invokeLater(this::rebuildTableRows);
-        }
-    }
-
-    private List<Integer> getHiddenRegions()
-    {
-        List<Integer> hiddenRegions = new ArrayList<>();
-
-        for (Region region : Region.values()) {
-            if (!Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", region.keyName))) {
-                hiddenRegions.add(region.ordinal());
-            }
-        }
-
-        return hiddenRegions;
-    }
+	private static final Color ODD_ROW_COLOR = new Color(44, 44, 44);
+
+	public static final int WORLD_COLUMN_WIDTH = 30;
+	public static final int TIER_COLUMN_WIDTH = 20;
+	public static final int DEAD_TIME_COLUMN_WIDTH = 40;
+	public static final int FOUND_BY_COLUMN_WIDTH = 50;
+
+	private static final int FETCH_TIMEOUT = 20 * 1000;
+
+	private long nextFetch = 0;
+
+	private TableHeader worldHeader;
+	private TableHeader tierHeader;
+	private TableHeader locationHeader;
+	private TableHeader deadTimeHeader;
+	private TableHeader foundByHeader;
+
+	private JPanel tableRowContainer;
+	private InfoPanel infoPanel;
+
+	@Inject
+	OkHttpClient okHttpClient;
+	@Inject
+	Gson gson;
+	@Inject
+	WorldService worldService;
+	@Inject
+	StarCallingAssistPlugin plugin;
+	@Inject
+	ConfigManager configManager;
+
+	@Getter
+	private OrderBy orderBy = OrderBy.TIER;
+
+	@Getter
+	@Setter
+	private boolean ascendingOrder = true;
+
+	private final List<TableRow> tableRows = new ArrayList<>();
+	private List<StarData> starData = new ArrayList<>();
+	private List<World> worldList = new ArrayList<>();
+
+	private class HeaderMouseListener extends MouseAdapter
+	{
+		private final OrderBy orderBy;
+		private final SidePanel sidePanel;
+
+		public HeaderMouseListener(OrderBy orderBy, SidePanel sidePanel)
+		{
+			this.orderBy = orderBy;
+			this.sidePanel = sidePanel;
+		}
+
+		@Override
+		public void mousePressed(MouseEvent mouseEvent)
+		{
+			if (SwingUtilities.isRightMouseButton(mouseEvent))
+			{
+				return;
+			}
+
+			sidePanel.setAscendingOrder(sidePanel.getOrderBy() != orderBy || !sidePanel.isAscendingOrder());
+			sidePanel.setOrderBy(orderBy);
+		}
+	}
+
+	public void init()
+	{
+		setBorder(null);
+		setLayout(new DynamicGridLayout(0, 1));
+
+		infoPanel = new InfoPanel(plugin);
+
+		JPanel headerContainer = buildTableHeader();
+		tableRowContainer = new JPanel();
+		tableRowContainer.setLayout(new GridLayout(0, 1));
+
+		add(infoPanel);
+		add(headerContainer);
+		add(tableRowContainer);
+
+		fetchWorldData();
+		fetchStarData();
+	}
+
+	public void updateInfoPanel()
+	{
+		infoPanel.rebuild();
+	}
+
+	public void updateTableRows()
+	{
+		tableRowContainer.removeAll();
+
+		tableRows.sort((r1, r2) ->
+		{
+			switch (orderBy)
+			{
+				case WORLD:
+					return ascendingOrder
+						? Integer.compare(r2.getData().getWorldId(), r1.getData().getWorldId())
+						: Integer.compare(r1.getData().getWorldId(), r2.getData().getWorldId());
+				case TIER:
+					return ascendingOrder
+						? Integer.compare(r2.getData().getTier(plugin.getConfig().estimateTier()), r1.getData().getTier(plugin.getConfig().estimateTier()))
+						: Integer.compare(r1.getData().getTier(plugin.getConfig().estimateTier()), r2.getData().getTier(plugin.getConfig().estimateTier()));
+				case LOCATION:
+					return ascendingOrder
+						? r2.getData().getLocation().compareTo(r1.getData().getLocation())
+						: r1.getData().getLocation().compareTo(r2.getData().getLocation());
+				case DEAD_TIME:
+					return ascendingOrder
+						? Integer.compare(r2.getData().getDeadTime(), r1.getData().getDeadTime())
+						: Integer.compare(r1.getData().getDeadTime(), r2.getData().getDeadTime());
+				default:
+					return 0;
+			}
+		});
+
+		for (TableRow row : tableRows)
+		{
+			row.setRowVisible(shouldBeVisible(row.getData()));
+
+			if (row.isRowVisible())
+			{
+				tableRowContainer.add(row);
+			}
+		}
+
+		colorRows();
+
+		tableRowContainer.revalidate();
+		tableRowContainer.repaint();
+	}
+
+	public void rebuildTableRows()
+	{
+		tableRows.clear();
+
+		for (StarData data : starData)
+		{
+			tableRows.add(new TableRow(data, plugin));
+		}
+
+		updateTableRows();
+	}
+
+	private boolean shouldBeVisible(StarData data)
+	{
+		if (data.isP2p() && !plugin.getConfig().showMembers())
+		{
+			return false;
+		}
+
+		if (!data.isP2p() && !plugin.getConfig().showF2P())
+		{
+			return false;
+		}
+
+		if (data.isPvp() && !plugin.getConfig().showPvp())
+		{
+			return false;
+		}
+
+		if (data.isHighRisk() && !plugin.getConfig().showHighRisk())
+		{
+			return false;
+		}
+
+		if (data.getTotalLevelType().ordinal() > plugin.getConfig().totalLevelType().ordinal())
+		{
+			return false;
+		}
+
+		if (data.getTier(plugin.getConfig().estimateTier()) < plugin.getConfig().minTier() ||
+			data.getTier(plugin.getConfig().estimateTier()) > plugin.getConfig().maxTier()
+		)
+		{
+			return false;
+		}
+
+		if (data.getDeadTime() < plugin.getConfig().minDeadTime())
+		{
+			return false;
+		}
+
+		Region[] regions = Region.values();
+
+		if (data.getRegion() >= 0 && data.getRegion() < regions.length)
+		{
+			return Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", regions[data.getRegion()].getKeyName()));
+		}
+
+		return true;
+	}
+
+	private void colorRows()
+	{
+		int i = 0;
+		for (TableRow row : tableRows)
+		{
+			if (!row.isRowVisible())
+			{
+				continue;
+			}
+
+			row.setBackground(i++ % 2 == 0
+				? ColorScheme.DARKER_GRAY_COLOR
+				: ODD_ROW_COLOR
+			);
+		}
+	}
+
+	private JPanel buildTableHeader()
+	{
+		JPanel header = new JPanel(new BorderLayout());
+		JPanel leftSide = new JPanel(new BorderLayout());
+		JPanel center = new JPanel(new BorderLayout());
+		JPanel rightSide = new JPanel(new BorderLayout());
+
+		worldHeader = new TableHeader("W", orderBy == OrderBy.WORLD, ascendingOrder);
+		worldHeader.setPreferredSize(new Dimension(WORLD_COLUMN_WIDTH, 0));
+		worldHeader.addMouseListener(new HeaderMouseListener(OrderBy.WORLD, this));
+
+		tierHeader = new TableHeader("T", orderBy == OrderBy.TIER, ascendingOrder);
+		tierHeader.setPreferredSize(new Dimension(TIER_COLUMN_WIDTH, 0));
+		tierHeader.addMouseListener(new HeaderMouseListener(OrderBy.TIER, this));
+
+		locationHeader = new TableHeader("Location", orderBy == OrderBy.LOCATION, ascendingOrder);
+		locationHeader.addMouseListener(new HeaderMouseListener(OrderBy.LOCATION, this));
+
+		deadTimeHeader = new TableHeader("Dead", orderBy == OrderBy.DEAD_TIME, ascendingOrder);
+		deadTimeHeader.setPreferredSize(new Dimension(DEAD_TIME_COLUMN_WIDTH, 0));
+		deadTimeHeader.addMouseListener(new HeaderMouseListener(OrderBy.DEAD_TIME, this));
+
+		foundByHeader = new TableHeader("Found by");
+		foundByHeader.setPreferredSize(new Dimension(FOUND_BY_COLUMN_WIDTH, 0));
+
+		leftSide.add(worldHeader, BorderLayout.WEST);
+		leftSide.add(tierHeader, BorderLayout.CENTER);
+		center.add(locationHeader, BorderLayout.CENTER);
+		rightSide.add(deadTimeHeader, BorderLayout.CENTER);
+		rightSide.add(foundByHeader, BorderLayout.EAST);
+
+		header.add(leftSide, BorderLayout.WEST);
+		header.add(center, BorderLayout.CENTER);
+		header.add(rightSide, BorderLayout.EAST);
+
+		return header;
+	}
+
+	public void setOrderBy(OrderBy order)
+	{
+		worldHeader.highlight(false, ascendingOrder);
+		tierHeader.highlight(false, ascendingOrder);
+		locationHeader.highlight(false, ascendingOrder);
+		deadTimeHeader.highlight(false, ascendingOrder);
+
+		switch (order)
+		{
+			case WORLD:
+				worldHeader.highlight(true, ascendingOrder);
+				break;
+			case TIER:
+				tierHeader.highlight(true, ascendingOrder);
+				break;
+			case LOCATION:
+				locationHeader.highlight(true, ascendingOrder);
+				break;
+			case DEAD_TIME:
+				deadTimeHeader.highlight(true, ascendingOrder);
+				break;
+		}
+		orderBy = order;
+		updateTableRows();
+	}
+
+	public void fetchWorldData()
+	{
+		WorldResult worldResult = worldService.getWorlds();
+		if (worldResult == null)
+		{
+			return;
+		}
+
+		List<World> worlds = worldResult.getWorlds();
+		if (worlds == null || worlds.isEmpty())
+		{
+			return;
+		}
+
+		worldList = worlds;
+	}
+
+	private World getWorldObject(int worldId)
+	{
+		return worldList.stream()
+			.filter(world -> world.getId() == worldId)
+			.findFirst()
+			.orElse(null);
+	}
+
+	public void fetchStarData()
+	{
+		// Don't fetch if less than 10s since last
+		if (nextFetch > System.currentTimeMillis())
+		{
+			return;
+		}
+
+		if (plugin.getConfig().getAuthorization().isEmpty())
+		{
+			SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
+			return;
+		}
+
+		if (plugin.getClient().getGameState() != GameState.LOGGED_IN)
+		{
+			SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("You need to be logged in to update the list!"));
+			return;
+		}
+
+		nextFetch = System.currentTimeMillis() + FETCH_TIMEOUT;
+
+		try
+		{
+			Request request = new Builder()
+				.url(plugin.getConfig().getEndpoint())
+				.addHeader("authorization", plugin.getConfig().getAuthorization())
+				.addHeader("plugin", plugin.getName())
+				.get()
+				.build();
+
+			okHttpClient.newCall(request).enqueue(new Callback()
+			{
+				@Override
+				public void onFailure(Call call, IOException e)
+				{
+					SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(e.getMessage()));
+					call.cancel();
+				}
+
+				@Override
+				public void onResponse(Call call, Response res) throws IOException
+				{
+					if (res.isSuccessful())
+					{
+						SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
+						parseData(res.body());
+					}
+					else
+					{
+						SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(res.message()));
+					}
+
+					res.close();
+				}
+			});
+		}
+		catch (IllegalArgumentException iae)
+		{
+			SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("Invalid endpoint!"));
+		}
+	}
+
+	private void parseData(@Nullable ResponseBody body)
+	{
+		List<StarData> starData = new ArrayList<>();
+		if (body == null)
+		{
+			return;
+		}
+
+		try
+		{
+			JsonArray jsonArray = gson.fromJson(body.string(), JsonArray.class);
+			if (jsonArray.size() < 1)
+			{
+				return;
+			}
+
+			for (final JsonElement element : jsonArray)
+			{
+				JsonObject obj = element.getAsJsonObject();
+				if (obj.has("world") &&
+					obj.has("tier") &&
+					obj.has("calledLocation") &&
+					obj.has("calledBy") &&
+					obj.has("calledAt") &&
+					obj.has("location")
+				)
+				{
+					starData.add(
+						new StarData(
+							obj.get("world").getAsInt(),
+							getWorldObject(obj.get("world").getAsInt()),
+							obj.get("tier").getAsInt(),
+							obj.get("calledLocation").getAsString(),
+							obj.get("calledBy").getAsString(),
+							obj.get("calledAt").getAsLong(),
+							obj.get("location").getAsInt()
+						)
+					);
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			log.error("Error parsing response! " + e.getMessage());
+		}
+
+		if (!starData.isEmpty())
+		{
+			this.starData = starData;
+			SwingUtilities.invokeLater(this::rebuildTableRows);
+		}
+	}
+
+	private List<Integer> getHiddenRegions()
+	{
+		List<Integer> hiddenRegions = new ArrayList<>();
+
+		for (Region region : Region.values())
+		{
+			if (!Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", region.keyName)))
+			{
+				hiddenRegions.add(region.ordinal());
+			}
+		}
+
+		return hiddenRegions;
+	}
 
 }

--- a/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
+++ b/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
@@ -30,7 +30,6 @@ import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 public class SidePanel extends PluginPanel
@@ -313,12 +312,10 @@ public class SidePanel extends PluginPanel
 
     private World getWorldObject(int worldId)
     {
-        Optional<World> result = worldList.stream().filter(world -> world.getId() == worldId).findFirst();
-        if (result.isPresent()) {
-            return result.get();
-        }
-
-        return null;
+        return worldList.stream()
+                        .filter(world -> world.getId() == worldId)
+                        .findFirst()
+                        .orElse(null);
     }
 
     public void fetchStarData()

--- a/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
+++ b/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
@@ -7,6 +7,15 @@ import com.google.gson.JsonObject;
 import com.starcallingassist.StarCallingAssistPlugin;
 import com.starcallingassist.sidepanel.constants.OrderBy;
 import com.starcallingassist.sidepanel.constants.Region;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.swing.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -18,18 +27,13 @@ import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldResult;
-import okhttp3.*;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
 import okhttp3.Request.Builder;
-
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 @Slf4j
 public class SidePanel extends PluginPanel

--- a/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
+++ b/src/main/java/com/starcallingassist/sidepanel/SidePanel.java
@@ -18,13 +18,8 @@ import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldResult;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
+import okhttp3.*;
 import okhttp3.Request.Builder;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -60,11 +55,16 @@ public class SidePanel extends PluginPanel
     private JPanel tableRowContainer;
     private InfoPanel infoPanel;
 
-    @Inject OkHttpClient okHttpClient;
-    @Inject Gson gson;
-    @Inject WorldService worldService;
-    @Inject StarCallingAssistPlugin plugin;
-    @Inject ConfigManager configManager;
+    @Inject
+    OkHttpClient okHttpClient;
+    @Inject
+    Gson gson;
+    @Inject
+    WorldService worldService;
+    @Inject
+    StarCallingAssistPlugin plugin;
+    @Inject
+    ConfigManager configManager;
 
     @Getter
     private OrderBy orderBy = OrderBy.TIER;
@@ -77,328 +77,360 @@ public class SidePanel extends PluginPanel
     private List<StarData> starData = new ArrayList<>();
     private List<World> worldList = new ArrayList<>();
 
-    private class HeaderMouseListener extends MouseAdapter {
-	private final OrderBy orderBy;
-	private final SidePanel sidePanel;
+    private class HeaderMouseListener extends MouseAdapter
+    {
+        private final OrderBy orderBy;
+        private final SidePanel sidePanel;
 
-	public HeaderMouseListener(OrderBy orderBy, SidePanel sidePanel) {
-	    this.orderBy = orderBy;
-	    this.sidePanel = sidePanel;
-	}
+        public HeaderMouseListener(OrderBy orderBy, SidePanel sidePanel)
+        {
+            this.orderBy = orderBy;
+            this.sidePanel = sidePanel;
+        }
 
-	@Override
-	public void mousePressed(MouseEvent mouseEvent) {
-	    if (SwingUtilities.isRightMouseButton(mouseEvent))
-		return;
-	    sidePanel.setAscendingOrder(sidePanel.getOrderBy() != orderBy || !sidePanel.isAscendingOrder());
-	    sidePanel.setOrderBy(orderBy);
-	}
+        @Override
+        public void mousePressed(MouseEvent mouseEvent)
+        {
+            if (SwingUtilities.isRightMouseButton(mouseEvent)) {
+                return;
+            }
+
+            sidePanel.setAscendingOrder(sidePanel.getOrderBy() != orderBy || !sidePanel.isAscendingOrder());
+            sidePanel.setOrderBy(orderBy);
+        }
     }
 
     public void init()
     {
-	setBorder(null);
-	setLayout(new DynamicGridLayout(0, 1));
+        setBorder(null);
+        setLayout(new DynamicGridLayout(0, 1));
 
-	infoPanel = new InfoPanel(plugin);
+        infoPanel = new InfoPanel(plugin);
 
-	JPanel headerContainer = buildTableHeader();
-	tableRowContainer = new JPanel();
-	tableRowContainer.setLayout(new GridLayout(0, 1));
+        JPanel headerContainer = buildTableHeader();
+        tableRowContainer = new JPanel();
+        tableRowContainer.setLayout(new GridLayout(0, 1));
 
-	add(infoPanel);
-	add(headerContainer);
-	add(tableRowContainer);
+        add(infoPanel);
+        add(headerContainer);
+        add(tableRowContainer);
 
-	fetchWorldData();
-	fetchStarData();
+        fetchWorldData();
+        fetchStarData();
     }
 
     public void updateInfoPanel()
     {
-	infoPanel.rebuild();
+        infoPanel.rebuild();
     }
 
     public void updateTableRows()
     {
-	tableRowContainer.removeAll();
+        tableRowContainer.removeAll();
 
-	tableRows.sort((r1, r2) ->
+        tableRows.sort((r1, r2) ->
         {
-	   switch (orderBy)
-	   {
-	       case WORLD:
-		   return ascendingOrder ? Integer.compare(r2.getData().getWorldId(), r1.getData().getWorldId()) : Integer.compare(r1.getData().getWorldId(), r2.getData().getWorldId());
-	       case TIER:
-		   return ascendingOrder ? Integer.compare(r2.getData().getTier(plugin.getConfig().estimateTier()), r1.getData().getTier(plugin.getConfig().estimateTier()))
-					 : Integer.compare(r1.getData().getTier(plugin.getConfig().estimateTier()), r2.getData().getTier(plugin.getConfig().estimateTier()));
-	       case LOCATION:
-		   return ascendingOrder ? r2.getData().getLocation().compareTo(r1.getData().getLocation()) : r1.getData().getLocation().compareTo(r2.getData().getLocation());
-	       case DEAD_TIME:
-		   return ascendingOrder ? Integer.compare(r2.getData().getDeadTime(), r1.getData().getDeadTime()) : Integer.compare(r1.getData().getDeadTime(), r2.getData().getDeadTime());
-	       default:
-		   return 0;
-	   }
+            switch (orderBy) {
+                case WORLD:
+                    return ascendingOrder
+                        ? Integer.compare(r2.getData().getWorldId(), r1.getData().getWorldId())
+                        : Integer.compare(r1.getData().getWorldId(), r2.getData().getWorldId());
+                case TIER:
+                    return ascendingOrder
+                        ? Integer.compare(r2.getData().getTier(plugin.getConfig().estimateTier()), r1.getData().getTier(plugin.getConfig().estimateTier()))
+                        : Integer.compare(r1.getData().getTier(plugin.getConfig().estimateTier()), r2.getData().getTier(plugin.getConfig().estimateTier()));
+                case LOCATION:
+                    return ascendingOrder
+                        ? r2.getData().getLocation().compareTo(r1.getData().getLocation())
+                        : r1.getData().getLocation().compareTo(r2.getData().getLocation());
+                case DEAD_TIME:
+                    return ascendingOrder
+                        ? Integer.compare(r2.getData().getDeadTime(), r1.getData().getDeadTime())
+                        : Integer.compare(r1.getData().getDeadTime(), r2.getData().getDeadTime());
+                default:
+                    return 0;
+            }
         });
 
-	for (TableRow row : tableRows)
-	{
-	    row.setRowVisible(shouldBeVisible(row.getData()));
-	    if(row.isRowVisible())
-		tableRowContainer.add(row);
-	}
+        for (TableRow row : tableRows) {
+            row.setRowVisible(shouldBeVisible(row.getData()));
 
-	colorRows();
+            if (row.isRowVisible()) {
+                tableRowContainer.add(row);
+            }
+        }
 
-	tableRowContainer.revalidate();
-	tableRowContainer.repaint();
+        colorRows();
+
+        tableRowContainer.revalidate();
+        tableRowContainer.repaint();
     }
 
     public void rebuildTableRows()
     {
-	tableRows.clear();
-	for (StarData data : starData)
-	    tableRows.add(new TableRow(data, plugin));
-	updateTableRows();
+        tableRows.clear();
+
+        for (StarData data : starData) {
+            tableRows.add(new TableRow(data, plugin));
+        }
+
+        updateTableRows();
     }
 
     private boolean shouldBeVisible(StarData data)
     {
-	if(data.isP2p() && !plugin.getConfig().showMembers())
-	    return false;
+        if (data.isP2p() && !plugin.getConfig().showMembers()) {
+            return false;
+        }
 
-	if(!data.isP2p() && !plugin.getConfig().showF2P())
-	    return false;
+        if (!data.isP2p() && !plugin.getConfig().showF2P()) {
+            return false;
+        }
 
-	if(data.isPvp() && !plugin.getConfig().showPvp())
-	    return false;
+        if (data.isPvp() && !plugin.getConfig().showPvp()) {
+            return false;
+        }
 
-	if(data.isHighRisk() && !plugin.getConfig().showHighRisk())
-	    return false;
+        if (data.isHighRisk() && !plugin.getConfig().showHighRisk()) {
+            return false;
+        }
 
-	if(data.getTotalLevelType().ordinal() > plugin.getConfig().totalLevelType().ordinal())
-	    return false;
+        if (data.getTotalLevelType().ordinal() > plugin.getConfig().totalLevelType().ordinal()) {
+            return false;
+        }
 
-	if(data.getTier(plugin.getConfig().estimateTier()) < plugin.getConfig().minTier() || data.getTier(plugin.getConfig().estimateTier()) > plugin.getConfig().maxTier())
-	    return false;
+        if (data.getTier(plugin.getConfig().estimateTier()) < plugin.getConfig().minTier() ||
+            data.getTier(plugin.getConfig().estimateTier()) > plugin.getConfig().maxTier()
+        ) {
+            return false;
+        }
 
-	if(data.getDeadTime() < plugin.getConfig().minDeadTime())
-	    return false;
+        if (data.getDeadTime() < plugin.getConfig().minDeadTime()) {
+            return false;
+        }
 
-	Region[] regions = Region.values();
+        Region[] regions = Region.values();
 
-	if(data.getRegion() >= 0 && data.getRegion() < regions.length)
-	    return Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", regions[data.getRegion()].getKeyName()));
+        if (data.getRegion() >= 0 && data.getRegion() < regions.length) {
+            return Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", regions[data.getRegion()].getKeyName()));
+        }
 
-	return true;
+        return true;
     }
 
     private void colorRows()
     {
-	int i = 0;
-	for(TableRow row : tableRows)
-	{
-	    if(!row.isRowVisible())
-		continue;
+        int i = 0;
+        for (TableRow row : tableRows) {
+            if (!row.isRowVisible()) {
+                continue;
+            }
 
-	    if(i++ % 2 == 0)
-		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-	    else
-		row.setBackground(ODD_ROW_COLOR);
-	}
+            row.setBackground(i++ % 2 == 0
+                ? ColorScheme.DARKER_GRAY_COLOR
+                : ODD_ROW_COLOR
+            );
+        }
     }
 
     private JPanel buildTableHeader()
     {
-	JPanel header = new JPanel(new BorderLayout());
-	JPanel leftSide = new JPanel(new BorderLayout());
-	JPanel center = new JPanel(new BorderLayout());
-	JPanel rightSide = new JPanel(new BorderLayout());
+        JPanel header = new JPanel(new BorderLayout());
+        JPanel leftSide = new JPanel(new BorderLayout());
+        JPanel center = new JPanel(new BorderLayout());
+        JPanel rightSide = new JPanel(new BorderLayout());
 
-	worldHeader = new TableHeader("W", orderBy == OrderBy.WORLD, ascendingOrder);
-	worldHeader.setPreferredSize(new Dimension(WORLD_COLUMN_WIDTH, 0));
-	worldHeader.addMouseListener(new HeaderMouseListener(OrderBy.WORLD, this));
+        worldHeader = new TableHeader("W", orderBy == OrderBy.WORLD, ascendingOrder);
+        worldHeader.setPreferredSize(new Dimension(WORLD_COLUMN_WIDTH, 0));
+        worldHeader.addMouseListener(new HeaderMouseListener(OrderBy.WORLD, this));
 
-	tierHeader = new TableHeader("T", orderBy == OrderBy.TIER, ascendingOrder);
-	tierHeader.setPreferredSize(new Dimension(TIER_COLUMN_WIDTH, 0));
-	tierHeader.addMouseListener(new HeaderMouseListener(OrderBy.TIER, this));
+        tierHeader = new TableHeader("T", orderBy == OrderBy.TIER, ascendingOrder);
+        tierHeader.setPreferredSize(new Dimension(TIER_COLUMN_WIDTH, 0));
+        tierHeader.addMouseListener(new HeaderMouseListener(OrderBy.TIER, this));
 
-	locationHeader = new TableHeader("Location", orderBy == OrderBy.LOCATION, ascendingOrder);
-	locationHeader.addMouseListener(new HeaderMouseListener(OrderBy.LOCATION, this));
+        locationHeader = new TableHeader("Location", orderBy == OrderBy.LOCATION, ascendingOrder);
+        locationHeader.addMouseListener(new HeaderMouseListener(OrderBy.LOCATION, this));
 
-	deadTimeHeader = new TableHeader("Dead", orderBy == OrderBy.DEAD_TIME, ascendingOrder);
-	deadTimeHeader.setPreferredSize(new Dimension(DEAD_TIME_COLUMN_WIDTH, 0));
-	deadTimeHeader.addMouseListener(new HeaderMouseListener(OrderBy.DEAD_TIME, this));
+        deadTimeHeader = new TableHeader("Dead", orderBy == OrderBy.DEAD_TIME, ascendingOrder);
+        deadTimeHeader.setPreferredSize(new Dimension(DEAD_TIME_COLUMN_WIDTH, 0));
+        deadTimeHeader.addMouseListener(new HeaderMouseListener(OrderBy.DEAD_TIME, this));
 
-	foundByHeader = new TableHeader("Found by");
-	foundByHeader.setPreferredSize(new Dimension(FOUND_BY_COLUMN_WIDTH, 0));
+        foundByHeader = new TableHeader("Found by");
+        foundByHeader.setPreferredSize(new Dimension(FOUND_BY_COLUMN_WIDTH, 0));
 
-	leftSide.add(worldHeader, BorderLayout.WEST);
-	leftSide.add(tierHeader, BorderLayout.CENTER);
-	center.add(locationHeader, BorderLayout.CENTER);
-	rightSide.add(deadTimeHeader, BorderLayout.CENTER);
-	rightSide.add(foundByHeader, BorderLayout.EAST);
+        leftSide.add(worldHeader, BorderLayout.WEST);
+        leftSide.add(tierHeader, BorderLayout.CENTER);
+        center.add(locationHeader, BorderLayout.CENTER);
+        rightSide.add(deadTimeHeader, BorderLayout.CENTER);
+        rightSide.add(foundByHeader, BorderLayout.EAST);
 
-	header.add(leftSide, BorderLayout.WEST);
-	header.add(center, BorderLayout.CENTER);
-	header.add(rightSide, BorderLayout.EAST);
+        header.add(leftSide, BorderLayout.WEST);
+        header.add(center, BorderLayout.CENTER);
+        header.add(rightSide, BorderLayout.EAST);
 
-	return header;
+        return header;
     }
 
     public void setOrderBy(OrderBy order)
     {
-	worldHeader.highlight(false, ascendingOrder);
-	tierHeader.highlight(false, ascendingOrder);
-	locationHeader.highlight(false, ascendingOrder);
-	deadTimeHeader.highlight(false, ascendingOrder);
+        worldHeader.highlight(false, ascendingOrder);
+        tierHeader.highlight(false, ascendingOrder);
+        locationHeader.highlight(false, ascendingOrder);
+        deadTimeHeader.highlight(false, ascendingOrder);
 
-	switch (order)
-	{
-	    case WORLD:
-		worldHeader.highlight(true, ascendingOrder);
-		break;
-	    case TIER:
-		tierHeader.highlight(true, ascendingOrder);
-		break;
-	    case LOCATION:
-		locationHeader.highlight(true, ascendingOrder);
-		break;
-	    case DEAD_TIME:
-		deadTimeHeader.highlight(true, ascendingOrder);
-		break;
-	}
-	orderBy = order;
-	updateTableRows();
+        switch (order) {
+            case WORLD:
+                worldHeader.highlight(true, ascendingOrder);
+                break;
+            case TIER:
+                tierHeader.highlight(true, ascendingOrder);
+                break;
+            case LOCATION:
+                locationHeader.highlight(true, ascendingOrder);
+                break;
+            case DEAD_TIME:
+                deadTimeHeader.highlight(true, ascendingOrder);
+                break;
+        }
+        orderBy = order;
+        updateTableRows();
     }
 
     public void fetchWorldData()
     {
-	WorldResult worldResult = worldService.getWorlds();
-	if(worldResult == null)
-	    return;
-	List<World> worlds = worldResult.getWorlds();
-	if (worlds == null || worlds.isEmpty())
-	    return;
-	worldList = worlds;
+        WorldResult worldResult = worldService.getWorlds();
+        if (worldResult == null) {
+            return;
+        }
+
+        List<World> worlds = worldResult.getWorlds();
+        if (worlds == null || worlds.isEmpty()) {
+            return;
+        }
+
+        worldList = worlds;
     }
 
     private World getWorldObject(int worldId)
     {
-	Optional<World> result = worldList.stream().filter(world -> world.getId() == worldId).findFirst();
-	if(result.isPresent())
-	    return result.get();
-	return null;
+        Optional<World> result = worldList.stream().filter(world -> world.getId() == worldId).findFirst();
+        if (result.isPresent()) {
+            return result.get();
+        }
+
+        return null;
     }
 
     public void fetchStarData()
     {
-	// Don't fetch if less than 10s since last
-	if(nextFetch > System.currentTimeMillis())
-	    return;
+        // Don't fetch if less than 10s since last
+        if (nextFetch > System.currentTimeMillis()) {
+            return;
+        }
 
-	if(plugin.getConfig().getAuthorization().isEmpty())
-	{
-	    SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
-	    return;
-	}
+        if (plugin.getConfig().getAuthorization().isEmpty()) {
+            SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
+            return;
+        }
 
-	if(plugin.getClient().getGameState() != GameState.LOGGED_IN)
-	{
-	    SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("You need to be logged in to update the list!"));
-	    return;
-	}
+        if (plugin.getClient().getGameState() != GameState.LOGGED_IN) {
+            SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("You need to be logged in to update the list!"));
+            return;
+        }
 
-	nextFetch = System.currentTimeMillis() + FETCH_TIMEOUT;
+        nextFetch = System.currentTimeMillis() + FETCH_TIMEOUT;
 
-	try
-	{
-	    Request request = new Builder()
-		    .url(plugin.getConfig().getEndpoint())
-		    .addHeader("authorization", plugin.getConfig().getAuthorization())
-		    .addHeader("plugin", plugin.getName())
-		    .get()
-		    .build();
+        try {
+            Request request = new Builder()
+                .url(plugin.getConfig().getEndpoint())
+                .addHeader("authorization", plugin.getConfig().getAuthorization())
+                .addHeader("plugin", plugin.getName())
+                .get()
+                .build();
 
-	    okHttpClient.newCall(request).enqueue(new Callback()
-	    {
-		@Override
-		public void onFailure(Call call, IOException e)
-		{
-		    SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(e.getMessage()));
-		    call.cancel();
-		}
-		@Override
-		public void onResponse(Call call, Response res) throws IOException
-		{
-		    if (res.isSuccessful()) {
-			SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
-			parseData(res.body());
-		    } else {
-			SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(res.message()));
-		    }
-		    res.close();
-		}
-	    });
-	}
-	catch (IllegalArgumentException iae)
-	{
-	    SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("Invalid endpoint!"));
-	}
+            okHttpClient.newCall(request).enqueue(new Callback()
+            {
+                @Override
+                public void onFailure(Call call, IOException e)
+                {
+                    SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(e.getMessage()));
+                    call.cancel();
+                }
+
+                @Override
+                public void onResponse(Call call, Response res) throws IOException
+                {
+                    if (res.isSuccessful()) {
+                        SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(""));
+                        parseData(res.body());
+                    } else {
+                        SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage(res.message()));
+                    }
+
+                    res.close();
+                }
+            });
+        } catch (IllegalArgumentException iae) {
+            SwingUtilities.invokeLater(() -> infoPanel.setErrorMessage("Invalid endpoint!"));
+        }
     }
 
     private void parseData(@Nullable ResponseBody body)
     {
-	List<StarData> starData = new ArrayList<>();
-	if(body == null)
-	    return;
+        List<StarData> starData = new ArrayList<>();
+        if (body == null) {
+            return;
+        }
 
-	try{
+        try {
+            JsonArray jsonArray = gson.fromJson(body.string(), JsonArray.class);
+            if (jsonArray.size() < 1) {
+                return;
+            }
 
-	    JsonArray jsonArray = gson.fromJson(body.string(), JsonArray.class);
-	    if(jsonArray.size() < 1)
-		return;
-	    for(final JsonElement element : jsonArray)
-	    {
-		JsonObject obj = element.getAsJsonObject();
-		if(obj.has("world") && obj.has("tier") &&
-		   obj.has("calledLocation") && obj.has("calledBy") &&
-		   obj.has("calledAt") && obj.has("location"))
-		{
-		    starData.add(
-			    new StarData(
-				    obj.get("world").getAsInt(),
-				    getWorldObject(obj.get("world").getAsInt()),
-				    obj.get("tier").getAsInt(),
-				    obj.get("calledLocation").getAsString(),
-				    obj.get("calledBy").getAsString(),
-				    obj.get("calledAt").getAsLong(),
-				    obj.get("location").getAsInt()
-			    )
-		    );
-		}
-	    }
-	}
-	catch (Exception e)
-	{
-	    log.error("Error parsing response! " + e.getMessage());
-	}
-	if(!starData.isEmpty())
-	{
-	    this.starData = starData;
-	    SwingUtilities.invokeLater(this::rebuildTableRows);
-	}
+            for (final JsonElement element : jsonArray) {
+                JsonObject obj = element.getAsJsonObject();
+                if (obj.has("world") &&
+                    obj.has("tier") &&
+                    obj.has("calledLocation") &&
+                    obj.has("calledBy") &&
+                    obj.has("calledAt") &&
+                    obj.has("location")
+                ) {
+                    starData.add(
+                        new StarData(
+                            obj.get("world").getAsInt(),
+                            getWorldObject(obj.get("world").getAsInt()),
+                            obj.get("tier").getAsInt(),
+                            obj.get("calledLocation").getAsString(),
+                            obj.get("calledBy").getAsString(),
+                            obj.get("calledAt").getAsLong(),
+                            obj.get("location").getAsInt()
+                        )
+                    );
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error parsing response! " + e.getMessage());
+        }
+
+        if (!starData.isEmpty()) {
+            this.starData = starData;
+            SwingUtilities.invokeLater(this::rebuildTableRows);
+        }
     }
 
     private List<Integer> getHiddenRegions()
     {
-	List<Integer> hiddenRegions = new ArrayList<>();
+        List<Integer> hiddenRegions = new ArrayList<>();
 
-	for(Region region : Region.values())
-	    if(!Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", region.keyName)))
-		hiddenRegions.add(region.ordinal());
+        for (Region region : Region.values()) {
+            if (!Boolean.parseBoolean(configManager.getConfiguration("starcallingassistplugin", region.keyName))) {
+                hiddenRegions.add(region.ordinal());
+            }
+        }
 
-	return hiddenRegions;
+        return hiddenRegions;
     }
 
 }

--- a/src/main/java/com/starcallingassist/sidepanel/StarData.java
+++ b/src/main/java/com/starcallingassist/sidepanel/StarData.java
@@ -1,177 +1,192 @@
 package com.starcallingassist.sidepanel;
 
 import com.starcallingassist.sidepanel.constants.TotalLevelType;
+import java.util.EnumSet;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.http.api.worlds.World;
 import net.runelite.http.api.worlds.WorldType;
 
-import java.util.EnumSet;
-
 @Slf4j
 public class StarData
 {
-    private int tier;
-    @Getter
-    private int worldId;
-    @Getter
-    private World world;
-    @Getter
-    private int region;
-    @Getter
-    private long updatedAt;
-    @Getter
-    private String location;
-    @Getter
-    private String foundBy;
+	private int tier;
+	@Getter
+	private int worldId;
+	@Getter
+	private World world;
+	@Getter
+	private int region;
+	@Getter
+	private long updatedAt;
+	@Getter
+	private String location;
+	@Getter
+	private String foundBy;
 
-    // Estimated time until dead for each tier in ms. Tier 0 at index 0, tier 1 at index 1 etc
-    private final int[] timeUntilDead = {
-        0,
-        1 * 7 * 60 * 1000,   // 7 minutes
-        2 * 7 * 60 * 1000,   // 14 minutes
-        3 * 7 * 60 * 1000,   // 21 minutes
-        4 * 7 * 60 * 1000,   // 28 minutes
-        5 * 7 * 60 * 1000,   // 35 minutes
-        6 * 7 * 60 * 1000,   // 42 minutes
-        7 * 7 * 60 * 1000,   // 49 minutes
-        8 * 7 * 60 * 1000,   // 56 minutes
-        9 * 7 * 60 * 1000    // 63 minutes
-    };
+	// Estimated time until dead for each tier in ms. Tier 0 at index 0, tier 1 at index 1 etc
+	private final int[] timeUntilDead = {
+		0,
+		1 * 7 * 60 * 1000,   // 7 minutes
+		2 * 7 * 60 * 1000,   // 14 minutes
+		3 * 7 * 60 * 1000,   // 21 minutes
+		4 * 7 * 60 * 1000,   // 28 minutes
+		5 * 7 * 60 * 1000,   // 35 minutes
+		6 * 7 * 60 * 1000,   // 42 minutes
+		7 * 7 * 60 * 1000,   // 49 minutes
+		8 * 7 * 60 * 1000,   // 56 minutes
+		9 * 7 * 60 * 1000    // 63 minutes
+	};
 
-    public StarData(int worldId, World world, int tier, String location, String foundBy, long updatedAt, int region)
-    {
-        this.worldId = worldId;
-        this.world = world;
-        this.tier = tier;
-        this.location = location;
-        this.foundBy = foundBy;
-        this.updatedAt = updatedAt;
-        this.region = region;
-    }
+	public StarData(int worldId, World world, int tier, String location, String foundBy, long updatedAt, int region)
+	{
+		this.worldId = worldId;
+		this.world = world;
+		this.tier = tier;
+		this.location = location;
+		this.foundBy = foundBy;
+		this.updatedAt = updatedAt;
+		this.region = region;
+	}
 
-    public int getTier(boolean estimate)
-    {
-        if (!estimate) {
-            return tier;
-        }
+	public int getTier(boolean estimate)
+	{
+		if (!estimate)
+		{
+			return tier;
+		}
 
-        long timeSinceUpdate = System.currentTimeMillis() - (updatedAt * 1000L);
+		long timeSinceUpdate = System.currentTimeMillis() - (updatedAt * 1000L);
 
-        for (int i = 0; i < timeUntilDead.length; i++) {
-            if (timeUntilDead[i] > (timeUntilDead[tier] - timeSinceUpdate)) {
-                return i;
-            }
-        }
+		for (int i = 0; i < timeUntilDead.length; i++)
+		{
+			if (timeUntilDead[i] > (timeUntilDead[tier] - timeSinceUpdate))
+			{
+				return i;
+			}
+		}
 
-        return 9;
-    }
+		return 9;
+	}
 
-    public int getDeadTime()
-    {
-        long deadAt = (updatedAt * 1000L) + timeUntilDead[tier];
+	public int getDeadTime()
+	{
+		long deadAt = (updatedAt * 1000L) + timeUntilDead[tier];
 
-        return (int) ((deadAt - System.currentTimeMillis()) / (60 * 1000));
-    }
+		return (int) ((deadAt - System.currentTimeMillis()) / (60 * 1000));
+	}
 
-    public EnumSet<WorldType> getWorldTypes()
-    {
-        if (world == null) {
-            return null;
-        }
+	public EnumSet<WorldType> getWorldTypes()
+	{
+		if (world == null)
+		{
+			return null;
+		}
 
-        return world.getTypes();
-    }
+		return world.getTypes();
+	}
 
-    public TotalLevelType getTotalLevelType()
-    {
-        if (!world.getTypes().contains(WorldType.SKILL_TOTAL)) {
-            return TotalLevelType.NONE;
-        }
+	public TotalLevelType getTotalLevelType()
+	{
+		if (!world.getTypes().contains(WorldType.SKILL_TOTAL))
+		{
+			return TotalLevelType.NONE;
+		}
 
-        switch (world.getActivity().substring(0, 4).trim()) {
-            case "500":
-                return TotalLevelType.TOTAL_500;
-            case "750":
-                return TotalLevelType.TOTAL_750;
-            case "1250":
-                return TotalLevelType.TOTAL_1250;
-            case "1500":
-                return TotalLevelType.TOTAL_1500;
-            case "1750":
-                return TotalLevelType.TOTAL_1750;
-            case "2000":
-                return TotalLevelType.TOTAL_2000;
-            case "2200":
-                return TotalLevelType.TOTAL_2200;
-            default:
-                return TotalLevelType.NONE;
-        }
-    }
+		switch (world.getActivity().substring(0, 4).trim())
+		{
+			case "500":
+				return TotalLevelType.TOTAL_500;
+			case "750":
+				return TotalLevelType.TOTAL_750;
+			case "1250":
+				return TotalLevelType.TOTAL_1250;
+			case "1500":
+				return TotalLevelType.TOTAL_1500;
+			case "1750":
+				return TotalLevelType.TOTAL_1750;
+			case "2000":
+				return TotalLevelType.TOTAL_2000;
+			case "2200":
+				return TotalLevelType.TOTAL_2200;
+			default:
+				return TotalLevelType.NONE;
+		}
+	}
 
-    public String getWorldTypeSpecifier()
-    {
-        if (world == null) {
-            return "";
-        }
+	public String getWorldTypeSpecifier()
+	{
+		if (world == null)
+		{
+			return "";
+		}
 
-        if (world.getTypes().contains(WorldType.SKILL_TOTAL)) {
-            return world.getActivity().substring(0, 4).trim();
-        }
+		if (world.getTypes().contains(WorldType.SKILL_TOTAL))
+		{
+			return world.getActivity().substring(0, 4).trim();
+		}
 
-        if (world.getTypes().contains(WorldType.PVP)) {
-            return "PVP";
-        }
+		if (world.getTypes().contains(WorldType.PVP))
+		{
+			return "PVP";
+		}
 
-        if (world.getTypes().contains(WorldType.HIGH_RISK)) {
-            return "HR";
-        }
+		if (world.getTypes().contains(WorldType.HIGH_RISK))
+		{
+			return "HR";
+		}
 
-        if (world.getTypes().contains(WorldType.BETA_WORLD)) {
-            return "Beta";
-        }
+		if (world.getTypes().contains(WorldType.BETA_WORLD))
+		{
+			return "Beta";
+		}
 
-        if (world.getTypes().contains(WorldType.DEADMAN)) {
-            return "DMM";
-        }
+		if (world.getTypes().contains(WorldType.DEADMAN))
+		{
+			return "DMM";
+		}
 
-        if (world.getTypes().contains(WorldType.SEASONAL)) {
-            return "S";
-        }
+		if (world.getTypes().contains(WorldType.SEASONAL))
+		{
+			return "S";
+		}
 
-        return "";
-    }
+		return "";
+	}
 
-    public boolean isWilderness()
-    {
-        return region == 13;
-    }
+	public boolean isWilderness()
+	{
+		return region == 13;
+	}
 
-    public boolean isPvp()
-    {
-        if (world == null) {
-            return true;
-        }
+	public boolean isPvp()
+	{
+		if (world == null)
+		{
+			return true;
+		}
 
-        return world.getTypes().contains(WorldType.PVP);
-    }
+		return world.getTypes().contains(WorldType.PVP);
+	}
 
-    public boolean isHighRisk()
-    {
-        if (world == null) {
-            return true;
-        }
+	public boolean isHighRisk()
+	{
+		if (world == null)
+		{
+			return true;
+		}
 
-        return world.getTypes().contains(WorldType.HIGH_RISK);
-    }
+		return world.getTypes().contains(WorldType.HIGH_RISK);
+	}
 
-    public boolean isP2p()
-    {
-        if (world == null) {
-            return true;
-        }
+	public boolean isP2p()
+	{
+		if (world == null)
+		{
+			return true;
+		}
 
-        return world.getTypes().contains(WorldType.MEMBERS);
-    }
+		return world.getTypes().contains(WorldType.MEMBERS);
+	}
 
 }

--- a/src/main/java/com/starcallingassist/sidepanel/StarData.java
+++ b/src/main/java/com/starcallingassist/sidepanel/StarData.java
@@ -27,125 +27,151 @@ public class StarData
 
     // Estimated time until dead for each tier in ms. Tier 0 at index 0, tier 1 at index 1 etc
     private final int[] timeUntilDead = {
-	0,
-	1 * 7 * 60 * 1000,   // 7 minutes
-	2 * 7 * 60 * 1000,   // 14 minutes
-	3 * 7 * 60 * 1000,   // 21 minutes
-	4 * 7 * 60 * 1000,   // 28 minutes
-	5 * 7 * 60 * 1000,   // 35 minutes
-	6 * 7 * 60 * 1000,   // 42 minutes
-	7 * 7 * 60 * 1000,   // 49 minutes
-	8 * 7 * 60 * 1000,   // 56 minutes
-	9 * 7 * 60 * 1000    // 63 minutes
+        0,
+        1 * 7 * 60 * 1000,   // 7 minutes
+        2 * 7 * 60 * 1000,   // 14 minutes
+        3 * 7 * 60 * 1000,   // 21 minutes
+        4 * 7 * 60 * 1000,   // 28 minutes
+        5 * 7 * 60 * 1000,   // 35 minutes
+        6 * 7 * 60 * 1000,   // 42 minutes
+        7 * 7 * 60 * 1000,   // 49 minutes
+        8 * 7 * 60 * 1000,   // 56 minutes
+        9 * 7 * 60 * 1000    // 63 minutes
     };
 
     public StarData(int worldId, World world, int tier, String location, String foundBy, long updatedAt, int region)
     {
-	this.worldId = worldId;
-	this.world = world;
-	this.tier = tier;
-	this.location = location;
-	this.foundBy = foundBy;
-	this.updatedAt = updatedAt;
-	this.region = region;
+        this.worldId = worldId;
+        this.world = world;
+        this.tier = tier;
+        this.location = location;
+        this.foundBy = foundBy;
+        this.updatedAt = updatedAt;
+        this.region = region;
     }
 
     public int getTier(boolean estimate)
     {
-	if(!estimate)
-	    return tier;
+        if (!estimate) {
+            return tier;
+        }
 
-	long timeSinceUpdate = System.currentTimeMillis() - (updatedAt * 1000L);
+        long timeSinceUpdate = System.currentTimeMillis() - (updatedAt * 1000L);
 
-	for(int i = 0; i < timeUntilDead.length; i++)
-	    if(timeUntilDead[i] > (timeUntilDead[tier] - timeSinceUpdate))
-		return i;
+        for (int i = 0; i < timeUntilDead.length; i++) {
+            if (timeUntilDead[i] > (timeUntilDead[tier] - timeSinceUpdate)) {
+                return i;
+            }
+        }
 
-	return 9;
+        return 9;
     }
 
     public int getDeadTime()
     {
-	long deadAt = (updatedAt * 1000L) + timeUntilDead[tier];
-	return (int)((deadAt - System.currentTimeMillis()) / (60 * 1000));
+        long deadAt = (updatedAt * 1000L) + timeUntilDead[tier];
+
+        return (int) ((deadAt - System.currentTimeMillis()) / (60 * 1000));
     }
 
     public EnumSet<WorldType> getWorldTypes()
     {
-	if(world == null)
-	    return null;
-	return world.getTypes();
+        if (world == null) {
+            return null;
+        }
+
+        return world.getTypes();
     }
 
     public TotalLevelType getTotalLevelType()
     {
-	if(!world.getTypes().contains(WorldType.SKILL_TOTAL))
-	    return TotalLevelType.NONE;
+        if (!world.getTypes().contains(WorldType.SKILL_TOTAL)) {
+            return TotalLevelType.NONE;
+        }
 
-	switch (world.getActivity().substring(0,4).trim())
-	{
-	    case "500":
-		return TotalLevelType.TOTAL_500;
-	    case "750":
-		return TotalLevelType.TOTAL_750;
-	    case "1250":
-		return TotalLevelType.TOTAL_1250;
-	    case "1500":
-		return TotalLevelType.TOTAL_1500;
-	    case "1750":
-		return TotalLevelType.TOTAL_1750;
-	    case "2000":
-		return TotalLevelType.TOTAL_2000;
-	    case "2200":
-		return TotalLevelType.TOTAL_2200;
-	    default:
-		return TotalLevelType.NONE;
-	}
+        switch (world.getActivity().substring(0, 4).trim()) {
+            case "500":
+                return TotalLevelType.TOTAL_500;
+            case "750":
+                return TotalLevelType.TOTAL_750;
+            case "1250":
+                return TotalLevelType.TOTAL_1250;
+            case "1500":
+                return TotalLevelType.TOTAL_1500;
+            case "1750":
+                return TotalLevelType.TOTAL_1750;
+            case "2000":
+                return TotalLevelType.TOTAL_2000;
+            case "2200":
+                return TotalLevelType.TOTAL_2200;
+            default:
+                return TotalLevelType.NONE;
+        }
     }
 
     public String getWorldTypeSpecifier()
     {
-	if(world == null)
-	    return "";
-	if(world.getTypes().contains(WorldType.SKILL_TOTAL))
-	    return world.getActivity().substring(0,4).trim();
-	if(world.getTypes().contains(WorldType.PVP))
-	    return "PVP";
-	if(world.getTypes().contains(WorldType.HIGH_RISK))
-	    return "HR";
-	if(world.getTypes().contains(WorldType.BETA_WORLD))
-	    return "Beta";
-	if(world.getTypes().contains(WorldType.DEADMAN))
-	    return "DMM";
-	if(world.getTypes().contains(WorldType.SEASONAL))
-	    return "S";
-	return "";
+        if (world == null) {
+            return "";
+        }
+
+        if (world.getTypes().contains(WorldType.SKILL_TOTAL)) {
+            return world.getActivity().substring(0, 4).trim();
+        }
+
+        if (world.getTypes().contains(WorldType.PVP)) {
+            return "PVP";
+        }
+
+        if (world.getTypes().contains(WorldType.HIGH_RISK)) {
+            return "HR";
+        }
+
+        if (world.getTypes().contains(WorldType.BETA_WORLD)) {
+            return "Beta";
+        }
+
+        if (world.getTypes().contains(WorldType.DEADMAN)) {
+            return "DMM";
+        }
+
+        if (world.getTypes().contains(WorldType.SEASONAL)) {
+            return "S";
+        }
+
+        return "";
     }
 
     public boolean isWilderness()
     {
-	return region == 13;
+        return region == 13;
     }
 
     public boolean isPvp()
     {
-	if(world == null)
-	    return true;
-	return world.getTypes().contains(WorldType.PVP);
+        if (world == null) {
+            return true;
+        }
+
+        return world.getTypes().contains(WorldType.PVP);
     }
 
     public boolean isHighRisk()
     {
-	if(world == null)
-	    return true;
-	return world.getTypes().contains(WorldType.HIGH_RISK);
+        if (world == null) {
+            return true;
+        }
+
+        return world.getTypes().contains(WorldType.HIGH_RISK);
     }
 
     public boolean isP2p()
     {
-	if(world == null)
-	    return true;
-	return world.getTypes().contains(WorldType.MEMBERS);
+        if (world == null) {
+            return true;
+        }
+
+        return world.getTypes().contains(WorldType.MEMBERS);
     }
 
 }

--- a/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
@@ -50,7 +50,8 @@ class TableHeader extends JPanel
     private static final Color ARROW_COLOR = ColorScheme.LIGHT_GRAY_COLOR;
     private static final Color HIGHLIGHT_COLOR = ColorScheme.BRAND_ORANGE;
 
-    static {
+    static
+    {
         final BufferedImage arrowDown = ImageUtil.loadImageResource(StarCallingAssistPlugin.class, "/arrow_down.png");
         final BufferedImage arrowUp = ImageUtil.rotateImage(arrowDown, Math.PI);
         final BufferedImage arrowUpFaded = ImageUtil.luminanceOffset(arrowUp, -80);

--- a/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
@@ -43,112 +43,114 @@ import net.runelite.client.util.ImageUtil;
 
 class TableHeader extends JPanel
 {
-    private static final ImageIcon ARROW_UP;
-    private static final ImageIcon HIGHLIGHT_ARROW_DOWN;
-    private static final ImageIcon HIGHLIGHT_ARROW_UP;
+	private static final ImageIcon ARROW_UP;
+	private static final ImageIcon HIGHLIGHT_ARROW_DOWN;
+	private static final ImageIcon HIGHLIGHT_ARROW_UP;
 
-    private static final Color ARROW_COLOR = ColorScheme.LIGHT_GRAY_COLOR;
-    private static final Color HIGHLIGHT_COLOR = ColorScheme.BRAND_ORANGE;
+	private static final Color ARROW_COLOR = ColorScheme.LIGHT_GRAY_COLOR;
+	private static final Color HIGHLIGHT_COLOR = ColorScheme.BRAND_ORANGE;
 
-    static
-    {
-        final BufferedImage arrowDown = ImageUtil.loadImageResource(StarCallingAssistPlugin.class, "/arrow_down.png");
-        final BufferedImage arrowUp = ImageUtil.rotateImage(arrowDown, Math.PI);
-        final BufferedImage arrowUpFaded = ImageUtil.luminanceOffset(arrowUp, -80);
-        ARROW_UP = new ImageIcon(arrowUpFaded);
+	static
+	{
+		final BufferedImage arrowDown = ImageUtil.loadImageResource(StarCallingAssistPlugin.class, "/arrow_down.png");
+		final BufferedImage arrowUp = ImageUtil.rotateImage(arrowDown, Math.PI);
+		final BufferedImage arrowUpFaded = ImageUtil.luminanceOffset(arrowUp, -80);
+		ARROW_UP = new ImageIcon(arrowUpFaded);
 
-        final BufferedImage highlightArrowDown = ImageUtil.fillImage(arrowDown, HIGHLIGHT_COLOR);
-        final BufferedImage highlightArrowUp = ImageUtil.fillImage(arrowUp, HIGHLIGHT_COLOR);
-        HIGHLIGHT_ARROW_DOWN = new ImageIcon(highlightArrowDown);
-        HIGHLIGHT_ARROW_UP = new ImageIcon(highlightArrowUp);
-    }
+		final BufferedImage highlightArrowDown = ImageUtil.fillImage(arrowDown, HIGHLIGHT_COLOR);
+		final BufferedImage highlightArrowUp = ImageUtil.fillImage(arrowUp, HIGHLIGHT_COLOR);
+		HIGHLIGHT_ARROW_DOWN = new ImageIcon(highlightArrowDown);
+		HIGHLIGHT_ARROW_UP = new ImageIcon(highlightArrowUp);
+	}
 
-    private final JLabel textLabel = new JLabel();
-    private final JLabel arrowLabel = new JLabel();
-    // Determines if this header column is being used to order the list
-    private boolean ordering = false;
+	private final JLabel textLabel = new JLabel();
+	private final JLabel arrowLabel = new JLabel();
+	// Determines if this header column is being used to order the list
+	private boolean ordering = false;
 
-    // Sortable
-    TableHeader(String title, boolean ordered, boolean ascending)
-    {
-        setLayout(new BorderLayout(0, 0));
-        setBackground(ColorScheme.SCROLL_TRACK_COLOR);
-        setBorder(new CompoundBorder(
-            BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
-            new EmptyBorder(0, 2, 0, -2)));
+	// Sortable
+	TableHeader(String title, boolean ordered, boolean ascending)
+	{
+		setLayout(new BorderLayout(0, 0));
+		setBackground(ColorScheme.SCROLL_TRACK_COLOR);
+		setBorder(new CompoundBorder(
+			BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
+			new EmptyBorder(0, 2, 0, -2)));
 
-        arrowLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
-        textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
+		arrowLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
+		textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
 
-        addMouseListener(new MouseAdapter()
-        {
-            @Override
-            public void mouseEntered(MouseEvent mouseEvent)
-            {
-                textLabel.setForeground(HIGHLIGHT_COLOR);
+		addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				textLabel.setForeground(HIGHLIGHT_COLOR);
 
-                if (!ordering) {
-                    arrowLabel.setIcon(HIGHLIGHT_ARROW_UP);
-                }
-            }
+				if (!ordering)
+				{
+					arrowLabel.setIcon(HIGHLIGHT_ARROW_UP);
+				}
+			}
 
-            @Override
-            public void mouseExited(MouseEvent mouseEvent)
-            {
-                if (!ordering) {
-                    textLabel.setForeground(ARROW_COLOR);
-                    arrowLabel.setIcon(ARROW_UP);
-                }
-            }
-        });
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				if (!ordering)
+				{
+					textLabel.setForeground(ARROW_COLOR);
+					arrowLabel.setIcon(ARROW_UP);
+				}
+			}
+		});
 
-        textLabel.setText(title);
-        textLabel.setFont(FontManager.getRunescapeSmallFont());
+		textLabel.setText(title);
+		textLabel.setFont(FontManager.getRunescapeSmallFont());
 
-        highlight(ordered, ascending);
+		highlight(ordered, ascending);
 
-        add(textLabel, BorderLayout.WEST);
-        add(arrowLabel, BorderLayout.EAST);
-    }
+		add(textLabel, BorderLayout.WEST);
+		add(arrowLabel, BorderLayout.EAST);
+	}
 
-    // Non-sortable
-    TableHeader(String title)
-    {
-        setLayout(new BorderLayout(0, 0));
-        setBackground(ColorScheme.SCROLL_TRACK_COLOR);
-        setBorder(new CompoundBorder(
-            BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
-            new EmptyBorder(0, 2, 0, -2)
-        ));
+	// Non-sortable
+	TableHeader(String title)
+	{
+		setLayout(new BorderLayout(0, 0));
+		setBackground(ColorScheme.SCROLL_TRACK_COLOR);
+		setBorder(new CompoundBorder(
+			BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
+			new EmptyBorder(0, 2, 0, -2)
+		));
 
-        textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
-        textLabel.setText(title);
-        textLabel.setFont(FontManager.getRunescapeSmallFont());
+		textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
+		textLabel.setText(title);
+		textLabel.setFont(FontManager.getRunescapeSmallFont());
 
-        add(textLabel, BorderLayout.WEST);
-    }
+		add(textLabel, BorderLayout.WEST);
+	}
 
-    /**
-     * The labels inherit the parent's mouse listeners.
-     */
-    @Override
-    public void addMouseListener(MouseListener mouseListener)
-    {
-        super.addMouseListener(mouseListener);
+	/**
+	 * The labels inherit the parent's mouse listeners.
+	 */
+	@Override
+	public void addMouseListener(MouseListener mouseListener)
+	{
+		super.addMouseListener(mouseListener);
 
-        textLabel.addMouseListener(mouseListener);
-        arrowLabel.addMouseListener(mouseListener);
-    }
+		textLabel.addMouseListener(mouseListener);
+		arrowLabel.addMouseListener(mouseListener);
+	}
 
-    /**
-     * If this column header is being used to order, then it should be
-     * highlighted, changing it's font color and icon.
-     */
-    public void highlight(boolean on, boolean ascending)
-    {
-        ordering = on;
-        arrowLabel.setIcon(on ? (ascending ? HIGHLIGHT_ARROW_DOWN : HIGHLIGHT_ARROW_UP) : ARROW_UP);
-        textLabel.setForeground(on ? HIGHLIGHT_COLOR : ARROW_COLOR);
-    }
+	/**
+	 * If this column header is being used to order, then it should be
+	 * highlighted, changing it's font color and icon.
+	 */
+	public void highlight(boolean on, boolean ascending)
+	{
+		ordering = on;
+		arrowLabel.setIcon(on ? (ascending ? HIGHLIGHT_ARROW_DOWN : HIGHLIGHT_ARROW_UP) : ARROW_UP);
+		textLabel.setForeground(on ? HIGHLIGHT_COLOR : ARROW_COLOR);
+	}
 
 }

--- a/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
@@ -24,23 +24,19 @@
  */
 package com.starcallingassist.sidepanel;
 
-	import java.awt.BorderLayout;
-	import java.awt.Color;
-	import java.awt.event.MouseAdapter;
-	import java.awt.event.MouseEvent;
-	import java.awt.event.MouseListener;
-	import java.awt.image.BufferedImage;
-	import javax.swing.BorderFactory;
-	import javax.swing.ImageIcon;
-	import javax.swing.JLabel;
-	import javax.swing.JPanel;
-	import javax.swing.border.CompoundBorder;
-	import javax.swing.border.EmptyBorder;
+import com.starcallingassist.StarCallingAssistPlugin;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.util.ImageUtil;
 
-	import com.starcallingassist.StarCallingAssistPlugin;
-	import net.runelite.client.ui.ColorScheme;
-	import net.runelite.client.ui.FontManager;
-	import net.runelite.client.util.ImageUtil;
+import javax.swing.*;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.image.BufferedImage;
 
 class TableHeader extends JPanel
 {
@@ -51,17 +47,16 @@ class TableHeader extends JPanel
     private static final Color ARROW_COLOR = ColorScheme.LIGHT_GRAY_COLOR;
     private static final Color HIGHLIGHT_COLOR = ColorScheme.BRAND_ORANGE;
 
-    static
-    {
-	final BufferedImage arrowDown = ImageUtil.loadImageResource(StarCallingAssistPlugin.class, "/arrow_down.png");
-	final BufferedImage arrowUp = ImageUtil.rotateImage(arrowDown, Math.PI);
-	final BufferedImage arrowUpFaded = ImageUtil.luminanceOffset(arrowUp, -80);
-	ARROW_UP = new ImageIcon(arrowUpFaded);
+    static {
+        final BufferedImage arrowDown = ImageUtil.loadImageResource(StarCallingAssistPlugin.class, "/arrow_down.png");
+        final BufferedImage arrowUp = ImageUtil.rotateImage(arrowDown, Math.PI);
+        final BufferedImage arrowUpFaded = ImageUtil.luminanceOffset(arrowUp, -80);
+        ARROW_UP = new ImageIcon(arrowUpFaded);
 
-	final BufferedImage highlightArrowDown = ImageUtil.fillImage(arrowDown, HIGHLIGHT_COLOR);
-	final BufferedImage highlightArrowUp = ImageUtil.fillImage(arrowUp, HIGHLIGHT_COLOR);
-	HIGHLIGHT_ARROW_DOWN = new ImageIcon(highlightArrowDown);
-	HIGHLIGHT_ARROW_UP = new ImageIcon(highlightArrowUp);
+        final BufferedImage highlightArrowDown = ImageUtil.fillImage(arrowDown, HIGHLIGHT_COLOR);
+        final BufferedImage highlightArrowUp = ImageUtil.fillImage(arrowUp, HIGHLIGHT_COLOR);
+        HIGHLIGHT_ARROW_DOWN = new ImageIcon(highlightArrowDown);
+        HIGHLIGHT_ARROW_UP = new ImageIcon(highlightArrowUp);
     }
 
     private final JLabel textLabel = new JLabel();
@@ -72,61 +67,61 @@ class TableHeader extends JPanel
     // Sortable
     TableHeader(String title, boolean ordered, boolean ascending)
     {
-	setLayout(new BorderLayout(0, 0));
-	setBackground(ColorScheme.SCROLL_TRACK_COLOR);
-	setBorder(new CompoundBorder(
-		BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
-		new EmptyBorder(0, 2, 0, -2)));
+        setLayout(new BorderLayout(0, 0));
+        setBackground(ColorScheme.SCROLL_TRACK_COLOR);
+        setBorder(new CompoundBorder(
+            BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
+            new EmptyBorder(0, 2, 0, -2)));
 
-	arrowLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
-	textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
+        arrowLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
+        textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
 
-	addMouseListener(new MouseAdapter()
-	{
-	    @Override
-	    public void mouseEntered(MouseEvent mouseEvent)
-	    {
-		textLabel.setForeground(HIGHLIGHT_COLOR);
-		if (!ordering)
-		{
-		    arrowLabel.setIcon(HIGHLIGHT_ARROW_UP);
-		}
-	    }
+        addMouseListener(new MouseAdapter()
+        {
+            @Override
+            public void mouseEntered(MouseEvent mouseEvent)
+            {
+                textLabel.setForeground(HIGHLIGHT_COLOR);
 
-	    @Override
-	    public void mouseExited(MouseEvent mouseEvent)
-	    {
-		if (!ordering)
-		{
-		    textLabel.setForeground(ARROW_COLOR);
-		    arrowLabel.setIcon(ARROW_UP);
-		}
-	    }
-	});
+                if (!ordering) {
+                    arrowLabel.setIcon(HIGHLIGHT_ARROW_UP);
+                }
+            }
 
-	textLabel.setText(title);
-	textLabel.setFont(FontManager.getRunescapeSmallFont());
+            @Override
+            public void mouseExited(MouseEvent mouseEvent)
+            {
+                if (!ordering) {
+                    textLabel.setForeground(ARROW_COLOR);
+                    arrowLabel.setIcon(ARROW_UP);
+                }
+            }
+        });
 
-	highlight(ordered, ascending);
+        textLabel.setText(title);
+        textLabel.setFont(FontManager.getRunescapeSmallFont());
 
-	add(textLabel, BorderLayout.WEST);
-	add(arrowLabel, BorderLayout.EAST);
+        highlight(ordered, ascending);
+
+        add(textLabel, BorderLayout.WEST);
+        add(arrowLabel, BorderLayout.EAST);
     }
 
     // Non-sortable
     TableHeader(String title)
     {
-	setLayout(new BorderLayout(0, 0));
-	setBackground(ColorScheme.SCROLL_TRACK_COLOR);
-	setBorder(new CompoundBorder(
-		BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
-		new EmptyBorder(0, 2, 0, -2)));
+        setLayout(new BorderLayout(0, 0));
+        setBackground(ColorScheme.SCROLL_TRACK_COLOR);
+        setBorder(new CompoundBorder(
+            BorderFactory.createMatteBorder(0, 0, 0, 1, ColorScheme.MEDIUM_GRAY_COLOR),
+            new EmptyBorder(0, 2, 0, -2)
+        ));
 
-	textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
-	textLabel.setText(title);
-	textLabel.setFont(FontManager.getRunescapeSmallFont());
+        textLabel.setBorder(new EmptyBorder(0, 0, 0, 0));
+        textLabel.setText(title);
+        textLabel.setFont(FontManager.getRunescapeSmallFont());
 
-	add(textLabel, BorderLayout.WEST);
+        add(textLabel, BorderLayout.WEST);
     }
 
     /**
@@ -135,9 +130,10 @@ class TableHeader extends JPanel
     @Override
     public void addMouseListener(MouseListener mouseListener)
     {
-	super.addMouseListener(mouseListener);
-	textLabel.addMouseListener(mouseListener);
-	arrowLabel.addMouseListener(mouseListener);
+        super.addMouseListener(mouseListener);
+
+        textLabel.addMouseListener(mouseListener);
+        arrowLabel.addMouseListener(mouseListener);
     }
 
     /**
@@ -146,9 +142,9 @@ class TableHeader extends JPanel
      */
     public void highlight(boolean on, boolean ascending)
     {
-	ordering = on;
-	arrowLabel.setIcon(on ? (ascending ? HIGHLIGHT_ARROW_DOWN : HIGHLIGHT_ARROW_UP) : ARROW_UP);
-	textLabel.setForeground(on ? HIGHLIGHT_COLOR : ARROW_COLOR);
+        ordering = on;
+        arrowLabel.setIcon(on ? (ascending ? HIGHLIGHT_ARROW_DOWN : HIGHLIGHT_ARROW_UP) : ARROW_UP);
+        textLabel.setForeground(on ? HIGHLIGHT_COLOR : ARROW_COLOR);
     }
 
 }

--- a/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableHeader.java
@@ -25,18 +25,21 @@
 package com.starcallingassist.sidepanel;
 
 import com.starcallingassist.StarCallingAssistPlugin;
-import net.runelite.client.ui.ColorScheme;
-import net.runelite.client.ui.FontManager;
-import net.runelite.client.util.ImageUtil;
-
-import javax.swing.*;
-import javax.swing.border.CompoundBorder;
-import javax.swing.border.EmptyBorder;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.util.ImageUtil;
 
 class TableHeader extends JPanel
 {

--- a/src/main/java/com/starcallingassist/sidepanel/TableRow.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableRow.java
@@ -25,6 +25,13 @@
 package com.starcallingassist.sidepanel;
 
 import com.starcallingassist.StarCallingAssistPlugin;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -33,14 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.FontManager;
-
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 public class TableRow extends JPanel

--- a/src/main/java/com/starcallingassist/sidepanel/TableRow.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableRow.java
@@ -168,23 +168,22 @@ public class TableRow extends JPanel
         JPanel column = new JPanel(new BorderLayout());
         column.setOpaque(false);
 
-        String worldTypeSpecifier = data.getWorldTypeSpecifier();
-
-        if (worldTypeSpecifier != "") {
-            worldTypeSpecifier = " " + worldTypeSpecifier;
-        }
-
         Color foreground = null;
 
         if (data.getWorldId() == plugin.getClient().getWorld()) {
             foreground = Color.GREEN;
-        } else if (data.getWorldTypeSpecifier() == "PVP") {
+        } else if (data.getWorldTypeSpecifier().equals("PVP")) {
             foreground = Color.RED;
         } else if (data.isP2p()) {
             foreground = Color.ORANGE;
         }
 
-        JPanel worldField = buildMultiLineTextField(data.getWorldId() + worldTypeSpecifier, 3, foreground);
+
+        JPanel worldField = buildMultiLineTextField(
+            (data.getWorldId() + " " + data.getWorldTypeSpecifier()).trim(),
+            3,
+            foreground
+        );
 
         worldField.setBorder(new EmptyBorder(0, 2, 0, 0));
         worldField.setPreferredSize(new Dimension(SidePanel.WORLD_COLUMN_WIDTH, 30));
@@ -200,7 +199,7 @@ public class TableRow extends JPanel
         JPanel column = new JPanel(new BorderLayout());
         column.setOpaque(false);
 
-        JLabel tierField = new JLabel(data.getTier(plugin.getConfig().estimateTier()) + "", SwingConstants.CENTER);
+        JLabel tierField = new JLabel(String.valueOf(data.getTier(plugin.getConfig().estimateTier())), SwingConstants.CENTER);
         tierField.setFont(FontManager.getRunescapeSmallFont());
         tierField.setPreferredSize(new Dimension(SidePanel.TIER_COLUMN_WIDTH, 30));
 

--- a/src/main/java/com/starcallingassist/sidepanel/TableRow.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableRow.java
@@ -25,12 +25,16 @@
 package com.starcallingassist.sidepanel;
 
 import com.starcallingassist.StarCallingAssistPlugin;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.*;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -44,311 +48,333 @@ import net.runelite.client.ui.FontManager;
 @Slf4j
 public class TableRow extends JPanel
 {
-    @Getter
-    private StarData data;
-
-    @Getter
-    @Setter
-    private boolean rowVisible;
-
-    private Color lastBackground;
-
-    private StarCallingAssistPlugin plugin;
-
-    // bubble up events
-    private final MouseAdapter labelMouseListener = new MouseAdapter()
-    {
-        @Override
-        public void mouseClicked(MouseEvent mouseEvent)
-        {
-            dispatchEvent(mouseEvent);
-        }
-
-        @Override
-        public void mousePressed(MouseEvent mouseEvent)
-        {
-            dispatchEvent(mouseEvent);
-        }
-
-        @Override
-        public void mouseReleased(MouseEvent mouseEvent)
-        {
-            dispatchEvent(mouseEvent);
-        }
-
-        @Override
-        public void mouseEntered(MouseEvent mouseEvent)
-        {
-            dispatchEvent(mouseEvent);
-        }
-
-        @Override
-        public void mouseExited(MouseEvent mouseEvent)
-        {
-            dispatchEvent(mouseEvent);
-        }
-    };
-
-    TableRow(StarData data, StarCallingAssistPlugin plugin)
-    {
-        this.data = data;
-        this.plugin = plugin;
-
-        setRowVisible(true);
-        setLayout(new BorderLayout());
-        setBorder(new EmptyBorder(2, 0, 2, 0));
-
-        addMouseListener(new MouseAdapter()
-        {
-            @Override
-            public void mouseClicked(MouseEvent mouseEvent)
-            {
-                if (mouseEvent.getButton() == MouseEvent.BUTTON1 && mouseEvent.getClickCount() == 2) {
-                    plugin.queueWorldHop(data.getWorldId());
-                }
-            }
-
-            @Override
-            public void mousePressed(MouseEvent mouseEvent)
-            {
-                if (mouseEvent.getClickCount() == 2) {
-                    setBackground(getBackground().brighter());
-                }
-            }
-
-            @Override
-            public void mouseReleased(MouseEvent mouseEvent)
-            {
-                if (mouseEvent.getClickCount() == 2) {
-                    setBackground(getBackground().darker());
-                }
-            }
-
-            @Override
-            public void mouseEntered(MouseEvent mouseEvent)
-            {
-                TableRow.this.lastBackground = getBackground();
-
-                setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
-            }
-
-            @Override
-            public void mouseExited(MouseEvent mouseEvent)
-            {
-                setBackground(lastBackground);
-            }
-        });
-
-        JPanel row = new JPanel(new BorderLayout());
-        JPanel leftSide = new JPanel(new BorderLayout());
-        JPanel center = new JPanel(new BorderLayout());
-        JPanel rightSide = new JPanel(new BorderLayout());
-
-        row.setOpaque(false);
-        leftSide.setOpaque(false);
-        center.setOpaque(false);
-        rightSide.setOpaque(false);
+	@Getter
+	private StarData data;
+
+	@Getter
+	@Setter
+	private boolean rowVisible;
+
+	private Color lastBackground;
+
+	private StarCallingAssistPlugin plugin;
+
+	// bubble up events
+	private final MouseAdapter labelMouseListener = new MouseAdapter()
+	{
+		@Override
+		public void mouseClicked(MouseEvent mouseEvent)
+		{
+			dispatchEvent(mouseEvent);
+		}
+
+		@Override
+		public void mousePressed(MouseEvent mouseEvent)
+		{
+			dispatchEvent(mouseEvent);
+		}
+
+		@Override
+		public void mouseReleased(MouseEvent mouseEvent)
+		{
+			dispatchEvent(mouseEvent);
+		}
+
+		@Override
+		public void mouseEntered(MouseEvent mouseEvent)
+		{
+			dispatchEvent(mouseEvent);
+		}
+
+		@Override
+		public void mouseExited(MouseEvent mouseEvent)
+		{
+			dispatchEvent(mouseEvent);
+		}
+	};
+
+	TableRow(StarData data, StarCallingAssistPlugin plugin)
+	{
+		this.data = data;
+		this.plugin = plugin;
+
+		setRowVisible(true);
+		setLayout(new BorderLayout());
+		setBorder(new EmptyBorder(2, 0, 2, 0));
+
+		addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent mouseEvent)
+			{
+				if (mouseEvent.getButton() == MouseEvent.BUTTON1 && mouseEvent.getClickCount() == 2)
+				{
+					plugin.queueWorldHop(data.getWorldId());
+				}
+			}
+
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+				if (mouseEvent.getClickCount() == 2)
+				{
+					setBackground(getBackground().brighter());
+				}
+			}
+
+			@Override
+			public void mouseReleased(MouseEvent mouseEvent)
+			{
+				if (mouseEvent.getClickCount() == 2)
+				{
+					setBackground(getBackground().darker());
+				}
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				TableRow.this.lastBackground = getBackground();
+
+				setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				setBackground(lastBackground);
+			}
+		});
+
+		JPanel row = new JPanel(new BorderLayout());
+		JPanel leftSide = new JPanel(new BorderLayout());
+		JPanel center = new JPanel(new BorderLayout());
+		JPanel rightSide = new JPanel(new BorderLayout());
+
+		row.setOpaque(false);
+		leftSide.setOpaque(false);
+		center.setOpaque(false);
+		rightSide.setOpaque(false);
+
+		leftSide.add(buildWorldField(), BorderLayout.WEST);
+		leftSide.add(buildTierField(), BorderLayout.CENTER);
+		center.add(buildLocationField(), BorderLayout.CENTER);
+		rightSide.add(buildDeadTimeField(), BorderLayout.CENTER);
+		rightSide.add(buildFoundByField(), BorderLayout.EAST);
 
-        leftSide.add(buildWorldField(), BorderLayout.WEST);
-        leftSide.add(buildTierField(), BorderLayout.CENTER);
-        center.add(buildLocationField(), BorderLayout.CENTER);
-        rightSide.add(buildDeadTimeField(), BorderLayout.CENTER);
-        rightSide.add(buildFoundByField(), BorderLayout.EAST);
+		row.add(leftSide, BorderLayout.WEST);
+		row.add(center, BorderLayout.CENTER);
+		row.add(rightSide, BorderLayout.EAST);
 
-        row.add(leftSide, BorderLayout.WEST);
-        row.add(center, BorderLayout.CENTER);
-        row.add(rightSide, BorderLayout.EAST);
+		add(row);
+	}
 
-        add(row);
-    }
+	private JPanel buildWorldField()
+	{
+		JPanel column = new JPanel(new BorderLayout());
+		column.setOpaque(false);
 
-    private JPanel buildWorldField()
-    {
-        JPanel column = new JPanel(new BorderLayout());
-        column.setOpaque(false);
+		Color foreground = null;
 
-        Color foreground = null;
+		if (data.getWorldId() == plugin.getClient().getWorld())
+		{
+			foreground = Color.GREEN;
+		}
+		else if (data.getWorldTypeSpecifier().equals("PVP"))
+		{
+			foreground = Color.RED;
+		}
+		else if (data.isP2p())
+		{
+			foreground = Color.ORANGE;
+		}
+
+
+		JPanel worldField = buildMultiLineTextField(
+			(data.getWorldId() + " " + data.getWorldTypeSpecifier()).trim(),
+			3,
+			foreground
+		);
+
+		worldField.setBorder(new EmptyBorder(0, 2, 0, 0));
+		worldField.setPreferredSize(new Dimension(SidePanel.WORLD_COLUMN_WIDTH, 30));
+
+		column.add(worldField);
+		column.addMouseListener(labelMouseListener);
+
+		return column;
+	}
 
-        if (data.getWorldId() == plugin.getClient().getWorld()) {
-            foreground = Color.GREEN;
-        } else if (data.getWorldTypeSpecifier().equals("PVP")) {
-            foreground = Color.RED;
-        } else if (data.isP2p()) {
-            foreground = Color.ORANGE;
-        }
-
-
-        JPanel worldField = buildMultiLineTextField(
-            (data.getWorldId() + " " + data.getWorldTypeSpecifier()).trim(),
-            3,
-            foreground
-        );
-
-        worldField.setBorder(new EmptyBorder(0, 2, 0, 0));
-        worldField.setPreferredSize(new Dimension(SidePanel.WORLD_COLUMN_WIDTH, 30));
-
-        column.add(worldField);
-        column.addMouseListener(labelMouseListener);
-
-        return column;
-    }
-
-    private JPanel buildTierField()
-    {
-        JPanel column = new JPanel(new BorderLayout());
-        column.setOpaque(false);
-
-        JLabel tierField = new JLabel(String.valueOf(data.getTier(plugin.getConfig().estimateTier())), SwingConstants.CENTER);
-        tierField.setFont(FontManager.getRunescapeSmallFont());
-        tierField.setPreferredSize(new Dimension(SidePanel.TIER_COLUMN_WIDTH, 30));
-
-        column.add(tierField);
-        column.addMouseListener(labelMouseListener);
-
-        return column;
-    }
-
-    private JPanel buildLocationField()
-    {
-        JPanel column = new JPanel(new BorderLayout());
-        column.setOpaque(false);
-
-        JPanel locationField = buildMultiLineTextField(data.getLocation(), 16, data.isWilderness() ? Color.RED : null);
-        locationField.setBorder(new EmptyBorder(0, 2, 0, 2));
-
-        column.add(locationField);
-        column.addMouseListener(labelMouseListener);
-
-        return column;
-    }
-
-    private JPanel buildDeadTimeField()
-    {
-        JPanel column = new JPanel(new BorderLayout());
-        column.setOpaque(false);
-
-        JLabel deadTimeField = new JLabel(data.getDeadTime() + "m");
-        deadTimeField.setForeground(data.getDeadTime() <= 0 ? Color.RED : data.getDeadTime() <= 20 ? Color.YELLOW : Color.GREEN);
-        deadTimeField.setHorizontalAlignment(SwingConstants.CENTER);
-        deadTimeField.setFont(FontManager.getRunescapeSmallFont());
-
-        deadTimeField.setPreferredSize(new Dimension(SidePanel.DEAD_TIME_COLUMN_WIDTH, 30));
-
-        column.add(deadTimeField);
-        column.addMouseListener(labelMouseListener);
-
-        return column;
-    }
-
-    private JPanel buildFoundByField()
-    {
-        JPanel column = new JPanel(new BorderLayout());
-        column.setOpaque(false);
-
-        JPanel foundByField = buildMultiLineTextField(fitUsername(data.getFoundBy(), 8), 8, null);
-
-        foundByField.setPreferredSize(new Dimension(SidePanel.FOUND_BY_COLUMN_WIDTH, 30));
-
-        column.add(foundByField);
-
-        column.addMouseListener(labelMouseListener);
-
-        return column;
-    }
-
-    /**
-     * Creates a JPanel containing one or more JLabels based on input.
-     *
-     * @param text       Text to divide into lines.
-     * @param charLimit  Maximum length of each line.
-     * @param foreground Color of the text.
-     * @return A JPanel containing one or more JLabels.
-     */
-    private JPanel buildMultiLineTextField(String text, int charLimit, Color foreground)
-    {
-        JPanel column = new JPanel(new DynamicGridLayout(3, 1));
-
-        List<String> lines = getLines(text, charLimit);
-
-        for (int i = 0; i < lines.size(); i++) {
-            if (i >= 3) {
-                break;
-            }
-
-            JLabel label = new JLabel(lines.get(i));
-            label.setFont(FontManager.getRunescapeSmallFont());
-            if (foreground != null) {
-                label.setForeground(foreground);
-            }
-
-            column.add(label);
-        }
-
-        column.setOpaque(false);
-
-        return column;
-    }
-
-    /**
-     * Divides a string into a list of lines based on the lineLength parameter.
-     *
-     * @param text       Text to divide into lines.
-     * @param lineLength Maximum length of each line.
-     * @return A list of String:s where all strings are less than lineLength in length.
-     */
-    private List<String> getLines(String text, int lineLength)
-    {
-        List<String> lines = new ArrayList<>();
-
-        String currentLine = "";
-        for (String s : text.split(" ")) {
-            if (s.length() + currentLine.length() + 1 > lineLength) {
-                if (currentLine.isEmpty()) {
-                    lines.add(s);
-                } else {
-                    lines.add(currentLine);
-                    currentLine = s;
-                }
-            } else {
-                currentLine += currentLine.isEmpty() ? s : (" " + s);
-            }
-        }
-
-        if (!currentLine.isEmpty()) {
-            lines.add(currentLine);
-        }
-
-        return lines;
-    }
-
-    /**
-     * Used as a workaround to make usernames word-wrap in the foundBy JLabel if they lack blankspaces
-     *
-     * @param username Username to process.
-     * @return A username altered with blankspaces to fit the foundBy JLabel.
-     */
-    private String fitUsername(String username, int charLimit)
-    {
-        if (username.length() > charLimit) {
-            String[] arr = username.split(" ");
-
-            for (int i = 0; i < arr.length; i++) {
-                if (arr[i].length() > charLimit - 1) {
-                    arr[i] = arr[i].substring(0, charLimit - 1) + " " + arr[i].substring(charLimit - 1);
-                }
-            }
-
-            username = String.join(" ", arr);
-        }
-
-        return username;
-    }
-
-    @Value
-    @AllArgsConstructor
-    private static class StringBool
-    {
-        String string;
-        boolean boolValue;
-    }
+	private JPanel buildTierField()
+	{
+		JPanel column = new JPanel(new BorderLayout());
+		column.setOpaque(false);
+
+		JLabel tierField = new JLabel(String.valueOf(data.getTier(plugin.getConfig().estimateTier())), SwingConstants.CENTER);
+		tierField.setFont(FontManager.getRunescapeSmallFont());
+		tierField.setPreferredSize(new Dimension(SidePanel.TIER_COLUMN_WIDTH, 30));
+
+		column.add(tierField);
+		column.addMouseListener(labelMouseListener);
+
+		return column;
+	}
+
+	private JPanel buildLocationField()
+	{
+		JPanel column = new JPanel(new BorderLayout());
+		column.setOpaque(false);
+
+		JPanel locationField = buildMultiLineTextField(data.getLocation(), 16, data.isWilderness() ? Color.RED : null);
+		locationField.setBorder(new EmptyBorder(0, 2, 0, 2));
+
+		column.add(locationField);
+		column.addMouseListener(labelMouseListener);
+
+		return column;
+	}
+
+	private JPanel buildDeadTimeField()
+	{
+		JPanel column = new JPanel(new BorderLayout());
+		column.setOpaque(false);
+
+		JLabel deadTimeField = new JLabel(data.getDeadTime() + "m");
+		deadTimeField.setForeground(data.getDeadTime() <= 0 ? Color.RED : data.getDeadTime() <= 20 ? Color.YELLOW : Color.GREEN);
+		deadTimeField.setHorizontalAlignment(SwingConstants.CENTER);
+		deadTimeField.setFont(FontManager.getRunescapeSmallFont());
+
+		deadTimeField.setPreferredSize(new Dimension(SidePanel.DEAD_TIME_COLUMN_WIDTH, 30));
+
+		column.add(deadTimeField);
+		column.addMouseListener(labelMouseListener);
+
+		return column;
+	}
+
+	private JPanel buildFoundByField()
+	{
+		JPanel column = new JPanel(new BorderLayout());
+		column.setOpaque(false);
+
+		JPanel foundByField = buildMultiLineTextField(fitUsername(data.getFoundBy(), 8), 8, null);
+
+		foundByField.setPreferredSize(new Dimension(SidePanel.FOUND_BY_COLUMN_WIDTH, 30));
+
+		column.add(foundByField);
+
+		column.addMouseListener(labelMouseListener);
+
+		return column;
+	}
+
+	/**
+	 * Creates a JPanel containing one or more JLabels based on input.
+	 *
+	 * @param text       Text to divide into lines.
+	 * @param charLimit  Maximum length of each line.
+	 * @param foreground Color of the text.
+	 * @return A JPanel containing one or more JLabels.
+	 */
+	private JPanel buildMultiLineTextField(String text, int charLimit, Color foreground)
+	{
+		JPanel column = new JPanel(new DynamicGridLayout(3, 1));
+
+		List<String> lines = getLines(text, charLimit);
+
+		for (int i = 0; i < lines.size(); i++)
+		{
+			if (i >= 3)
+			{
+				break;
+			}
+
+			JLabel label = new JLabel(lines.get(i));
+			label.setFont(FontManager.getRunescapeSmallFont());
+			if (foreground != null)
+			{
+				label.setForeground(foreground);
+			}
+
+			column.add(label);
+		}
+
+		column.setOpaque(false);
+
+		return column;
+	}
+
+	/**
+	 * Divides a string into a list of lines based on the lineLength parameter.
+	 *
+	 * @param text       Text to divide into lines.
+	 * @param lineLength Maximum length of each line.
+	 * @return A list of String:s where all strings are less than lineLength in length.
+	 */
+	private List<String> getLines(String text, int lineLength)
+	{
+		List<String> lines = new ArrayList<>();
+
+		String currentLine = "";
+		for (String s : text.split(" "))
+		{
+			if (s.length() + currentLine.length() + 1 > lineLength)
+			{
+				if (currentLine.isEmpty())
+				{
+					lines.add(s);
+				}
+				else
+				{
+					lines.add(currentLine);
+					currentLine = s;
+				}
+			}
+			else
+			{
+				currentLine += currentLine.isEmpty() ? s : (" " + s);
+			}
+		}
+
+		if (!currentLine.isEmpty())
+		{
+			lines.add(currentLine);
+		}
+
+		return lines;
+	}
+
+	/**
+	 * Used as a workaround to make usernames word-wrap in the foundBy JLabel if they lack blankspaces
+	 *
+	 * @param username Username to process.
+	 * @return A username altered with blankspaces to fit the foundBy JLabel.
+	 */
+	private String fitUsername(String username, int charLimit)
+	{
+		if (username.length() > charLimit)
+		{
+			String[] arr = username.split(" ");
+
+			for (int i = 0; i < arr.length; i++)
+			{
+				if (arr[i].length() > charLimit - 1)
+				{
+					arr[i] = arr[i].substring(0, charLimit - 1) + " " + arr[i].substring(charLimit - 1);
+				}
+			}
+
+			username = String.join(" ", arr);
+		}
+
+		return username;
+	}
+
+	@Value
+	@AllArgsConstructor
+	private static class StringBool
+	{
+		String string;
+		boolean boolValue;
+	}
 }

--- a/src/main/java/com/starcallingassist/sidepanel/TableRow.java
+++ b/src/main/java/com/starcallingassist/sidepanel/TableRow.java
@@ -24,23 +24,23 @@
  */
 package com.starcallingassist.sidepanel;
 
-	import java.awt.*;
-	import java.awt.event.MouseAdapter;
-	import java.awt.event.MouseEvent;
-	import java.util.ArrayList;
-	import java.util.List;
-	import javax.swing.*;
-	import javax.swing.border.EmptyBorder;
+import com.starcallingassist.StarCallingAssistPlugin;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.DynamicGridLayout;
+import net.runelite.client.ui.FontManager;
 
-	import com.starcallingassist.StarCallingAssistPlugin;
-	import lombok.AllArgsConstructor;
-	import lombok.Getter;
-	import lombok.Setter;
-	import lombok.Value;
-	import lombok.extern.slf4j.Slf4j;
-	import net.runelite.client.ui.ColorScheme;
-	import net.runelite.client.ui.DynamicGridLayout;
-	import net.runelite.client.ui.FontManager;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 public class TableRow extends JPanel
@@ -59,267 +59,268 @@ public class TableRow extends JPanel
     // bubble up events
     private final MouseAdapter labelMouseListener = new MouseAdapter()
     {
-	@Override
-	public void mouseClicked(MouseEvent mouseEvent)
-	{
-	    dispatchEvent(mouseEvent);
-	}
+        @Override
+        public void mouseClicked(MouseEvent mouseEvent)
+        {
+            dispatchEvent(mouseEvent);
+        }
 
-	@Override
-	public void mousePressed(MouseEvent mouseEvent)
-	{
-	    dispatchEvent(mouseEvent);
-	}
+        @Override
+        public void mousePressed(MouseEvent mouseEvent)
+        {
+            dispatchEvent(mouseEvent);
+        }
 
-	@Override
-	public void mouseReleased(MouseEvent mouseEvent)
-	{
-	    dispatchEvent(mouseEvent);
-	}
+        @Override
+        public void mouseReleased(MouseEvent mouseEvent)
+        {
+            dispatchEvent(mouseEvent);
+        }
 
-	@Override
-	public void mouseEntered(MouseEvent mouseEvent)
-	{
-	    dispatchEvent(mouseEvent);
-	}
+        @Override
+        public void mouseEntered(MouseEvent mouseEvent)
+        {
+            dispatchEvent(mouseEvent);
+        }
 
-	@Override
-	public void mouseExited(MouseEvent mouseEvent)
-	{
-	    dispatchEvent(mouseEvent);
-	}
+        @Override
+        public void mouseExited(MouseEvent mouseEvent)
+        {
+            dispatchEvent(mouseEvent);
+        }
     };
 
     TableRow(StarData data, StarCallingAssistPlugin plugin)
     {
-	this.data = data;
-	this.plugin = plugin;
+        this.data = data;
+        this.plugin = plugin;
 
-	setRowVisible(true);
-	setLayout(new BorderLayout());
-	setBorder(new EmptyBorder(2, 0, 2, 0));
+        setRowVisible(true);
+        setLayout(new BorderLayout());
+        setBorder(new EmptyBorder(2, 0, 2, 0));
 
-	addMouseListener(new MouseAdapter()
-	{
-	    @Override
-	    public void mouseClicked(MouseEvent mouseEvent)
-	    {
-		if (mouseEvent.getButton() == MouseEvent.BUTTON1 && mouseEvent.getClickCount() == 2)
-		    plugin.queueWorldHop(data.getWorldId());
-	    }
+        addMouseListener(new MouseAdapter()
+        {
+            @Override
+            public void mouseClicked(MouseEvent mouseEvent)
+            {
+                if (mouseEvent.getButton() == MouseEvent.BUTTON1 && mouseEvent.getClickCount() == 2) {
+                    plugin.queueWorldHop(data.getWorldId());
+                }
+            }
 
-	    @Override
-	    public void mousePressed(MouseEvent mouseEvent)
-	    {
-		if (mouseEvent.getClickCount() == 2)
-		    setBackground(getBackground().brighter());
-	    }
+            @Override
+            public void mousePressed(MouseEvent mouseEvent)
+            {
+                if (mouseEvent.getClickCount() == 2) {
+                    setBackground(getBackground().brighter());
+                }
+            }
 
-	    @Override
-	    public void mouseReleased(MouseEvent mouseEvent)
-	    {
-		if (mouseEvent.getClickCount() == 2)
-		    setBackground(getBackground().darker());
-	    }
+            @Override
+            public void mouseReleased(MouseEvent mouseEvent)
+            {
+                if (mouseEvent.getClickCount() == 2) {
+                    setBackground(getBackground().darker());
+                }
+            }
 
-	    @Override
-	    public void mouseEntered(MouseEvent mouseEvent)
-	    {
-		TableRow.this.lastBackground = getBackground();
+            @Override
+            public void mouseEntered(MouseEvent mouseEvent)
+            {
+                TableRow.this.lastBackground = getBackground();
 
-		setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
-	    }
+                setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+            }
 
-	    @Override
-	    public void mouseExited(MouseEvent mouseEvent)
-	    {
-		setBackground(lastBackground);
-	    }
-	});
+            @Override
+            public void mouseExited(MouseEvent mouseEvent)
+            {
+                setBackground(lastBackground);
+            }
+        });
 
-	JPanel row = new JPanel(new BorderLayout());
-	JPanel leftSide = new JPanel(new BorderLayout());
-	JPanel center = new JPanel(new BorderLayout());
-	JPanel rightSide = new JPanel(new BorderLayout());
+        JPanel row = new JPanel(new BorderLayout());
+        JPanel leftSide = new JPanel(new BorderLayout());
+        JPanel center = new JPanel(new BorderLayout());
+        JPanel rightSide = new JPanel(new BorderLayout());
 
-	row.setOpaque(false);
-	leftSide.setOpaque(false);
-	center.setOpaque(false);
-	rightSide.setOpaque(false);
+        row.setOpaque(false);
+        leftSide.setOpaque(false);
+        center.setOpaque(false);
+        rightSide.setOpaque(false);
 
-	leftSide.add(buildWorldField(), BorderLayout.WEST);
-	leftSide.add(buildTierField(), BorderLayout.CENTER);
-	center.add(buildLocationField(), BorderLayout.CENTER);
-	rightSide.add(buildDeadTimeField(), BorderLayout.CENTER);
-	rightSide.add(buildFoundByField(), BorderLayout.EAST);
+        leftSide.add(buildWorldField(), BorderLayout.WEST);
+        leftSide.add(buildTierField(), BorderLayout.CENTER);
+        center.add(buildLocationField(), BorderLayout.CENTER);
+        rightSide.add(buildDeadTimeField(), BorderLayout.CENTER);
+        rightSide.add(buildFoundByField(), BorderLayout.EAST);
 
-	row.add(leftSide, BorderLayout.WEST);
-	row.add(center, BorderLayout.CENTER);
-	row.add(rightSide, BorderLayout.EAST);
+        row.add(leftSide, BorderLayout.WEST);
+        row.add(center, BorderLayout.CENTER);
+        row.add(rightSide, BorderLayout.EAST);
 
-	add(row);
+        add(row);
     }
 
     private JPanel buildWorldField()
     {
-	JPanel column = new JPanel(new BorderLayout());
-	column.setOpaque(false);
+        JPanel column = new JPanel(new BorderLayout());
+        column.setOpaque(false);
 
-	String worldTypeSpecifier = data.getWorldTypeSpecifier();
+        String worldTypeSpecifier = data.getWorldTypeSpecifier();
 
-	if(worldTypeSpecifier != "")
-	    worldTypeSpecifier = " " + worldTypeSpecifier;
+        if (worldTypeSpecifier != "") {
+            worldTypeSpecifier = " " + worldTypeSpecifier;
+        }
 
-	Color foreground = null;
+        Color foreground = null;
 
-	if(data.getWorldId() == plugin.getClient().getWorld())
-	    foreground = Color.GREEN;
-	else if(data.getWorldTypeSpecifier() == "PVP")
-	    foreground = Color.RED;
-	else if(data.isP2p())
-	    foreground = Color.ORANGE;
+        if (data.getWorldId() == plugin.getClient().getWorld()) {
+            foreground = Color.GREEN;
+        } else if (data.getWorldTypeSpecifier() == "PVP") {
+            foreground = Color.RED;
+        } else if (data.isP2p()) {
+            foreground = Color.ORANGE;
+        }
 
-	JPanel worldField = buildMultiLineTextField(data.getWorldId() + worldTypeSpecifier, 3, foreground);
+        JPanel worldField = buildMultiLineTextField(data.getWorldId() + worldTypeSpecifier, 3, foreground);
 
-	worldField.setBorder(new EmptyBorder(0, 2, 0, 0));
-	worldField.setPreferredSize(new Dimension(SidePanel.WORLD_COLUMN_WIDTH, 30));
+        worldField.setBorder(new EmptyBorder(0, 2, 0, 0));
+        worldField.setPreferredSize(new Dimension(SidePanel.WORLD_COLUMN_WIDTH, 30));
 
-	column.add(worldField);
-	column.addMouseListener(labelMouseListener);
+        column.add(worldField);
+        column.addMouseListener(labelMouseListener);
 
-	return column;
+        return column;
     }
 
     private JPanel buildTierField()
     {
-	JPanel column = new JPanel(new BorderLayout());
-	column.setOpaque(false);
+        JPanel column = new JPanel(new BorderLayout());
+        column.setOpaque(false);
 
-	JLabel tierField = new JLabel(data.getTier(plugin.getConfig().estimateTier()) + "", SwingConstants.CENTER);
-	tierField.setFont(FontManager.getRunescapeSmallFont());
-	tierField.setPreferredSize(new Dimension(SidePanel.TIER_COLUMN_WIDTH, 30));
+        JLabel tierField = new JLabel(data.getTier(plugin.getConfig().estimateTier()) + "", SwingConstants.CENTER);
+        tierField.setFont(FontManager.getRunescapeSmallFont());
+        tierField.setPreferredSize(new Dimension(SidePanel.TIER_COLUMN_WIDTH, 30));
 
-	column.add(tierField);
-	column.addMouseListener(labelMouseListener);
+        column.add(tierField);
+        column.addMouseListener(labelMouseListener);
 
-	return column;
+        return column;
     }
 
     private JPanel buildLocationField()
     {
+        JPanel column = new JPanel(new BorderLayout());
+        column.setOpaque(false);
 
-	JPanel column = new JPanel(new BorderLayout());
-	column.setOpaque(false);
+        JPanel locationField = buildMultiLineTextField(data.getLocation(), 16, data.isWilderness() ? Color.RED : null);
+        locationField.setBorder(new EmptyBorder(0, 2, 0, 2));
 
-	JPanel locationField = buildMultiLineTextField(data.getLocation(), 16, data.isWilderness() ? Color.RED : null);
-	locationField.setBorder(new EmptyBorder(0, 2, 0, 2));
+        column.add(locationField);
+        column.addMouseListener(labelMouseListener);
 
-	column.add(locationField);
-	column.addMouseListener(labelMouseListener);
-
-	return column;
+        return column;
     }
 
     private JPanel buildDeadTimeField()
     {
-	JPanel column = new JPanel(new BorderLayout());
-	column.setOpaque(false);
+        JPanel column = new JPanel(new BorderLayout());
+        column.setOpaque(false);
 
-	JLabel deadTimeField = new JLabel(data.getDeadTime() + "m");
-	deadTimeField.setForeground(data.getDeadTime() <= 0 ? Color.RED : data.getDeadTime() <= 20 ? Color.YELLOW : Color.GREEN);
-	deadTimeField.setHorizontalAlignment(SwingConstants.CENTER);
-	deadTimeField.setFont(FontManager.getRunescapeSmallFont());
+        JLabel deadTimeField = new JLabel(data.getDeadTime() + "m");
+        deadTimeField.setForeground(data.getDeadTime() <= 0 ? Color.RED : data.getDeadTime() <= 20 ? Color.YELLOW : Color.GREEN);
+        deadTimeField.setHorizontalAlignment(SwingConstants.CENTER);
+        deadTimeField.setFont(FontManager.getRunescapeSmallFont());
 
-	deadTimeField.setPreferredSize(new Dimension(SidePanel.DEAD_TIME_COLUMN_WIDTH, 30));
+        deadTimeField.setPreferredSize(new Dimension(SidePanel.DEAD_TIME_COLUMN_WIDTH, 30));
 
-	column.add(deadTimeField);
-	column.addMouseListener(labelMouseListener);
+        column.add(deadTimeField);
+        column.addMouseListener(labelMouseListener);
 
-	return column;
+        return column;
     }
 
     private JPanel buildFoundByField()
     {
-	JPanel column = new JPanel(new BorderLayout());
-	column.setOpaque(false);
+        JPanel column = new JPanel(new BorderLayout());
+        column.setOpaque(false);
 
-	JPanel foundByField = buildMultiLineTextField(fitUsername(data.getFoundBy(), 8), 8,  null);
+        JPanel foundByField = buildMultiLineTextField(fitUsername(data.getFoundBy(), 8), 8, null);
 
-	foundByField.setPreferredSize(new Dimension(SidePanel.FOUND_BY_COLUMN_WIDTH, 30));
+        foundByField.setPreferredSize(new Dimension(SidePanel.FOUND_BY_COLUMN_WIDTH, 30));
 
-	column.add(foundByField);
+        column.add(foundByField);
 
-	column.addMouseListener(labelMouseListener);
+        column.addMouseListener(labelMouseListener);
 
-	return column;
+        return column;
     }
 
     /**
      * Creates a JPanel containing one or more JLabels based on input.
      *
-     * @param text Text to divide into lines.
-     * @param charLimit Maximum length of each line.
+     * @param text       Text to divide into lines.
+     * @param charLimit  Maximum length of each line.
      * @param foreground Color of the text.
      * @return A JPanel containing one or more JLabels.
      */
     private JPanel buildMultiLineTextField(String text, int charLimit, Color foreground)
     {
-	JPanel column = new JPanel(new DynamicGridLayout(3, 1));
+        JPanel column = new JPanel(new DynamicGridLayout(3, 1));
 
-	List<String> lines = getLines(text, charLimit);
+        List<String> lines = getLines(text, charLimit);
 
-	for (int i = 0; i < lines.size(); i++)
-	{
-	    if(i >= 3)
-		break;
-	    JLabel label = new JLabel(lines.get(i));
-	    label.setFont(FontManager.getRunescapeSmallFont());
-	    if(foreground != null)
-		label.setForeground(foreground);
-	    column.add(label);
-	}
+        for (int i = 0; i < lines.size(); i++) {
+            if (i >= 3) {
+                break;
+            }
 
-	column.setOpaque(false);
+            JLabel label = new JLabel(lines.get(i));
+            label.setFont(FontManager.getRunescapeSmallFont());
+            if (foreground != null) {
+                label.setForeground(foreground);
+            }
 
-	return column;
+            column.add(label);
+        }
+
+        column.setOpaque(false);
+
+        return column;
     }
 
     /**
      * Divides a string into a list of lines based on the lineLength parameter.
      *
-     * @param text Text to divide into lines.
+     * @param text       Text to divide into lines.
      * @param lineLength Maximum length of each line.
      * @return A list of String:s where all strings are less than lineLength in length.
      */
     private List<String> getLines(String text, int lineLength)
     {
-	List<String> lines = new ArrayList<>();
+        List<String> lines = new ArrayList<>();
 
-	String currentLine = "";
-	for (String s : text.split(" "))
-	{
-	    if(s.length() + currentLine.length() + 1 > lineLength)
-	    {
-		if(currentLine.isEmpty())
-		{
-		    lines.add(s);
-		}
-		else
-		{
-		    lines.add(currentLine);
-		    currentLine = s;
-		}
-	    }
-	    else
-	    {
-		currentLine += currentLine.isEmpty() ? s : (" " + s);
-	    }
-	}
+        String currentLine = "";
+        for (String s : text.split(" ")) {
+            if (s.length() + currentLine.length() + 1 > lineLength) {
+                if (currentLine.isEmpty()) {
+                    lines.add(s);
+                } else {
+                    lines.add(currentLine);
+                    currentLine = s;
+                }
+            } else {
+                currentLine += currentLine.isEmpty() ? s : (" " + s);
+            }
+        }
 
-	if(!currentLine.isEmpty())
-	    lines.add(currentLine);
+        if (!currentLine.isEmpty()) {
+            lines.add(currentLine);
+        }
 
-	return lines;
+        return lines;
     }
 
     /**
@@ -330,22 +331,26 @@ public class TableRow extends JPanel
      */
     private String fitUsername(String username, int charLimit)
     {
-	if(username.length() > charLimit)
-	{
-	    String[] arr = username.split(" ");
-	    for(int i = 0; i < arr.length; i++)
-		if(arr[i].length() > charLimit - 1)
-		    arr[i] = arr[i].substring(0, charLimit - 1) + " " + arr[i].substring(charLimit - 1);
-	    username = String.join(" ", arr);
-	}
-	return username;
+        if (username.length() > charLimit) {
+            String[] arr = username.split(" ");
+
+            for (int i = 0; i < arr.length; i++) {
+                if (arr[i].length() > charLimit - 1) {
+                    arr[i] = arr[i].substring(0, charLimit - 1) + " " + arr[i].substring(charLimit - 1);
+                }
+            }
+
+            username = String.join(" ", arr);
+        }
+
+        return username;
     }
 
     @Value
     @AllArgsConstructor
     private static class StringBool
     {
-	String string;
-	boolean boolValue;
+        String string;
+        boolean boolValue;
     }
 }

--- a/src/main/java/com/starcallingassist/sidepanel/constants/OrderBy.java
+++ b/src/main/java/com/starcallingassist/sidepanel/constants/OrderBy.java
@@ -2,8 +2,8 @@ package com.starcallingassist.sidepanel.constants;
 
 public enum OrderBy
 {
-    WORLD,
-    TIER,
-    LOCATION,
-    DEAD_TIME,
+	WORLD,
+	TIER,
+	LOCATION,
+	DEAD_TIME,
 }

--- a/src/main/java/com/starcallingassist/sidepanel/constants/Region.java
+++ b/src/main/java/com/starcallingassist/sidepanel/constants/Region.java
@@ -20,11 +20,13 @@ public enum Region
 
     public final String keyName;
 
-    Region(String keyName) {
-	this.keyName = keyName;
+    Region(String keyName)
+    {
+        this.keyName = keyName;
     }
 
-    public String getKeyName() {
-	return keyName;
+    public String getKeyName()
+    {
+        return keyName;
     }
 }

--- a/src/main/java/com/starcallingassist/sidepanel/constants/Region.java
+++ b/src/main/java/com/starcallingassist/sidepanel/constants/Region.java
@@ -2,31 +2,31 @@ package com.starcallingassist.sidepanel.constants;
 
 public enum Region
 {
-    ASGARNIA(RegionKeyName.KEY_ASGARNIA),
-    KARAMJA(RegionKeyName.KEY_KARAMJA),
-    FELDIP(RegionKeyName.KEY_FELDIP),
-    FOSSIL(RegionKeyName.KEY_FOSSIL),
-    FREMMENIK(RegionKeyName.KEY_FREMMENIK),
-    KOUREND(RegionKeyName.KEY_KOUREND),
-    KANDARIN(RegionKeyName.KEY_KANDARIN),
-    KEBOS(RegionKeyName.KEY_KEBOS),
-    DESERT(RegionKeyName.KEY_DESERT),
-    MISTHALIN(RegionKeyName.KEY_MISTHALIN),
-    MORYTANIA(RegionKeyName.KEY_MORYTANIA),
-    GNOME(RegionKeyName.KEY_GNOME),
-    TIRANNWN(RegionKeyName.KEY_TIRANNWN),
-    WILDERNESS(RegionKeyName.KEY_WILDERNESS),
-    UNKNOWN(RegionKeyName.KEY_UNKNOWN);
+	ASGARNIA(RegionKeyName.KEY_ASGARNIA),
+	KARAMJA(RegionKeyName.KEY_KARAMJA),
+	FELDIP(RegionKeyName.KEY_FELDIP),
+	FOSSIL(RegionKeyName.KEY_FOSSIL),
+	FREMMENIK(RegionKeyName.KEY_FREMMENIK),
+	KOUREND(RegionKeyName.KEY_KOUREND),
+	KANDARIN(RegionKeyName.KEY_KANDARIN),
+	KEBOS(RegionKeyName.KEY_KEBOS),
+	DESERT(RegionKeyName.KEY_DESERT),
+	MISTHALIN(RegionKeyName.KEY_MISTHALIN),
+	MORYTANIA(RegionKeyName.KEY_MORYTANIA),
+	GNOME(RegionKeyName.KEY_GNOME),
+	TIRANNWN(RegionKeyName.KEY_TIRANNWN),
+	WILDERNESS(RegionKeyName.KEY_WILDERNESS),
+	UNKNOWN(RegionKeyName.KEY_UNKNOWN);
 
-    public final String keyName;
+	public final String keyName;
 
-    Region(String keyName)
-    {
-        this.keyName = keyName;
-    }
+	Region(String keyName)
+	{
+		this.keyName = keyName;
+	}
 
-    public String getKeyName()
-    {
-        return keyName;
-    }
+	public String getKeyName()
+	{
+		return keyName;
+	}
 }

--- a/src/main/java/com/starcallingassist/sidepanel/constants/RegionKeyName.java
+++ b/src/main/java/com/starcallingassist/sidepanel/constants/RegionKeyName.java
@@ -2,19 +2,19 @@ package com.starcallingassist.sidepanel.constants;
 
 public class RegionKeyName
 {
-    public static final String KEY_ASGARNIA = "asgarnia";
-    public static final String KEY_KARAMJA = "karamja";
-    public static final String KEY_FELDIP = "feldip";
-    public static final String KEY_FOSSIL = "fossil";
-    public static final String KEY_FREMMENIK = "fremmenik";
-    public static final String KEY_KOUREND = "kourend";
-    public static final String KEY_KANDARIN = "kandarin";
-    public static final String KEY_KEBOS = "kebos";
-    public static final String KEY_DESERT = "desert";
-    public static final String KEY_MISTHALIN = "misthalin";
-    public static final String KEY_MORYTANIA = "morytania";
-    public static final String KEY_GNOME = "gnome";
-    public static final String KEY_TIRANNWN = "tirannwn";
-    public static final String KEY_WILDERNESS = "wilderness";
-    public static final String KEY_UNKNOWN = "unknown";
+	public static final String KEY_ASGARNIA = "asgarnia";
+	public static final String KEY_KARAMJA = "karamja";
+	public static final String KEY_FELDIP = "feldip";
+	public static final String KEY_FOSSIL = "fossil";
+	public static final String KEY_FREMMENIK = "fremmenik";
+	public static final String KEY_KOUREND = "kourend";
+	public static final String KEY_KANDARIN = "kandarin";
+	public static final String KEY_KEBOS = "kebos";
+	public static final String KEY_DESERT = "desert";
+	public static final String KEY_MISTHALIN = "misthalin";
+	public static final String KEY_MORYTANIA = "morytania";
+	public static final String KEY_GNOME = "gnome";
+	public static final String KEY_TIRANNWN = "tirannwn";
+	public static final String KEY_WILDERNESS = "wilderness";
+	public static final String KEY_UNKNOWN = "unknown";
 }

--- a/src/main/java/com/starcallingassist/sidepanel/constants/TotalLevelType.java
+++ b/src/main/java/com/starcallingassist/sidepanel/constants/TotalLevelType.java
@@ -2,12 +2,12 @@ package com.starcallingassist.sidepanel.constants;
 
 public enum TotalLevelType
 {
-    NONE,
-    TOTAL_500,
-    TOTAL_750,
-    TOTAL_1250,
-    TOTAL_1500,
-    TOTAL_1750,
-    TOTAL_2000,
-    TOTAL_2200
+	NONE,
+	TOTAL_500,
+	TOTAL_750,
+	TOTAL_1250,
+	TOTAL_1500,
+	TOTAL_1750,
+	TOTAL_2000,
+	TOTAL_2200
 }

--- a/src/test/java/com/starcallingassist/StarCallingAssistPluginTest.java
+++ b/src/test/java/com/starcallingassist/StarCallingAssistPluginTest.java
@@ -5,9 +5,9 @@ import net.runelite.client.externalplugins.ExternalPluginManager;
 
 public class StarCallingAssistPluginTest
 {
-    public static void main(String[] args) throws Exception
-    {
-        ExternalPluginManager.loadBuiltin(StarCallingAssistPlugin.class);
-        RuneLite.main(args);
-    }
+	public static void main(String[] args) throws Exception
+	{
+		ExternalPluginManager.loadBuiltin(StarCallingAssistPlugin.class);
+		RuneLite.main(args);
+	}
 }

--- a/src/test/java/com/starcallingassist/StarCallingAssistPluginTest.java
+++ b/src/test/java/com/starcallingassist/StarCallingAssistPluginTest.java
@@ -5,9 +5,9 @@ import net.runelite.client.externalplugins.ExternalPluginManager;
 
 public class StarCallingAssistPluginTest
 {
-	public static void main(String[] args) throws Exception
-	{
-		ExternalPluginManager.loadBuiltin(StarCallingAssistPlugin.class);
-		RuneLite.main(args);
-	}
+    public static void main(String[] args) throws Exception
+    {
+        ExternalPluginManager.loadBuiltin(StarCallingAssistPlugin.class);
+        RuneLite.main(args);
+    }
 }


### PR DESCRIPTION
This PR fixes the formatting/indentation to be more uniform:
- Consistent indentation all across the codebase
- Consistent bracketing use around `for` and `if` statements
- Slightly opinionated "code grouping" in a few places to make things visually easier to follow.

Additionally and arguably more important, I've made the following actual logic changes:
- Fix: The onConfigChanged for the "endpoint" key never triggered (https://github.com/zodaz/star-calling-assist/commit/33c941f6b1ebc0881e28cc71cf3c426e9be98e99)
- The `getWorldObject` method Optional chain can be simplified using a single chain-operator (https://github.com/zodaz/star-calling-assist/commit/6ffefb52a7beb6ec0c908e13d25e178a3bdc4efe)
- Null-safe comparison on Widget children (removeCallButton method, https://github.com/zodaz/star-calling-assist/commit/4cf5bb2504ddfe117f452ff574804ca9995c5a92)
- Consistent early-returns on native event listeners (https://github.com/zodaz/star-calling-assist/commit/a24bde2b4273b47254fcba622f0abe22b6f567c1)
- Simplified the world label (F2P, PVP etc.) on the SidePanel's TableRow (https://github.com/zodaz/star-calling-assist/commit/cfd48eae6747042ec6b7569be3e2da945bebff8e)

---

I recommend reviewing this using the "Hide whitespace" Github diff option enabled, otherwise it's simply not doable. In either case, the whitespace-only changes are really just auto-formatted to be consistent using spaces. The non-whitespace changes are mostly manually made, so those are really the only ones that matter.
![CleanShot 2023-10-27 at 13 18 58](https://github.com/zodaz/star-calling-assist/assets/1752195/c5fc226a-be19-4eb9-b891-1381767bbebb)
