### PR TITLE
Add color to SidePanel star entry text for world type

### DIFF
--- a/src/main/java/com/starcallingassist/constants/PluginColors.java
+++ b/src/main/java/com/starcallingassist/constants/PluginColors.java
@@ -43,4 +43,5 @@ public class PluginColors
 	public static final Color SPEEDRUNNING_WORLD = new Color(94, 213, 201);
 	public static final Color FRESH_START_WORLD = new Color(255, 211, 83);
 	public static final Color MEMBERS_WORLD = new Color(210, 193, 53);
+	public static final Color PVP_WORLD = new Color(220, 38, 38);
 }

--- a/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
+++ b/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
@@ -272,6 +272,10 @@ public class StarListEntryAttributes
 		{
 			return PluginColors.PVP_WORLD;
 		}
+		else if (types.contains(WorldType.HIGH_RISK))
+		{
+			return PluginColors.STAR_LIST_GROUP_LABEL;
+		}
 
 		return null;
 	}

--- a/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
+++ b/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
@@ -263,6 +263,10 @@ public class StarListEntryAttributes
 		{
 			return PluginColors.FRESH_START_WORLD;
 		}
+		else if (types.contains(WorldType.PVP) || types.contains(WorldType.HIGH_RISK))
+		{
+			return PluginColors.PVP_WORLD;
+		}
 
 		return null;
 	}

--- a/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
+++ b/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
@@ -171,7 +171,7 @@ public class StarListEntryAttributes
 
 		EnumSet<WorldType> types = world.getTypes();
 
-		if (types.contains(WorldType.PVP) || types.contains(WorldType.HIGH_RISK) || types.contains(WorldType.DEADMAN))
+		if (types.contains(WorldType.PVP) || types.contains(WorldType.DEADMAN))
 		{
 			return PluginColors.DANGEROUS_AREA;
 		}

--- a/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
+++ b/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
@@ -211,6 +211,11 @@ public class StarListEntryAttributes
 			return world.getActivity().substring(0, 4) + " Total";
 		}
 
+		if (world.getTypes().contains(WorldType.PVP) && world.getTypes().contains(WorldType.HIGH_RISK))
+		{
+			return "High-risk PvP";
+		}
+
 		if (world.getTypes().contains(WorldType.PVP))
 		{
 			return "PvP World";

--- a/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
+++ b/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
@@ -263,7 +263,7 @@ public class StarListEntryAttributes
 		{
 			return PluginColors.FRESH_START_WORLD;
 		}
-		else if (types.contains(WorldType.PVP) || types.contains(WorldType.HIGH_RISK))
+		else if (types.contains(WorldType.PVP))
 		{
 			return PluginColors.PVP_WORLD;
 		}

--- a/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
+++ b/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
@@ -218,7 +218,7 @@ public class StarListEntryAttributes
 
 		if (world.getTypes().contains(WorldType.HIGH_RISK))
 		{
-			return "High-risk PvP";
+			return "High-risk";
 		}
 
 		if (world.getTypes().contains(WorldType.BETA_WORLD))

--- a/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
+++ b/src/main/java/com/starcallingassist/modules/sidepanel/objects/StarListEntryAttributes.java
@@ -243,7 +243,7 @@ public class StarListEntryAttributes
 	{
 		EnumSet<WorldType> types = world.getTypes();
 
-		if (world.getTypes().contains(WorldType.SKILL_TOTAL))
+		if (types.contains(WorldType.SKILL_TOTAL))
 		{
 			return PluginColors.TOTAL_LEVEL_RESTRICTED_WORLD;
 		}


### PR DESCRIPTION
* Adds a `PVP_WORLD` color to the `PluginColors` constant [`35d5deb`](https://github.com/zodaz/star-calling-assist/pull/6/commits/35d5debd4030fd736809fef81fca058a14d8538c)
* Adds logic in `getWorldLimitationColor()` of `StarListEntryAttributes` for PVP worlds [`44379f6`](https://github.com/zodaz/star-calling-assist/pull/6/commits/44379f6c278878286961d0bd214e4171e45f895b),[`1b2e953`](https://github.com/zodaz/star-calling-assist/pull/6/commits/1b2e953c41968f864a305bf92c8525b57b05b87e)
* Fixes a code inconsistency in `PluginColors` [`66c204c`](https://github.com/zodaz/star-calling-assist/pull/6/commits/66c204c3eb38fdf021fc40f3229441efefa436d0)